### PR TITLE
api: require explicit core output and normalize builders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Replace `begin_request_owned` / `begin_request_with_owned` with `begin_owned_request` / `begin_owned_request_with`.
 - `RunBuilder::new` now returns `RunBuilderError`, and completed assembly uses `RunBuilder::build()` instead of `finish()`. Invalid zero worker counts are rejected by `push_runtime_snapshot` before retention.
 - Core runtime-sampler registration plumbing and the audience-selecting validation-summary helper are no longer supported root APIs; use the Tokio sampler startup errors and the two purpose-specific validation summary functions.
+- Controller template validation now uses `ControllerTemplateError`. `ReloadConfigError::Validate` and `ReloadTemplateError::Validate` carry that type instead of core `BuildError`; callers matching those variants must update their patterns and type references accordingly.
 
 - Split direct shutdown failures into `ShutdownError::UnfinishedRequests` and
   `ShutdownError::Sink`, narrowing `SinkError` to sink-produced failures. Consolidated controller

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Changed
 
+### 0.4 core API migration
+
+- Direct `Tailtriage::builder(...)` capture now requires `.output(...)` or `.sink(...)`; omission returns `BuildError::MissingSink` instead of implicitly writing `tailtriage-run.json`.
+- Replace `.light()` / `.investigation()` with `.mode(CaptureMode::Light)` / `.mode(CaptureMode::Investigation)`, and `selected_mode()` with `capture_mode()`.
+- Replace `begin_request_owned` / `begin_request_with_owned` with `begin_owned_request` / `begin_owned_request_with`.
+- `RunBuilder::new` now returns `RunBuilderError`, and completed assembly uses `RunBuilder::build()` instead of `finish()`. Invalid zero worker counts are rejected by `push_runtime_snapshot` before retention.
+- Core runtime-sampler registration plumbing and the audience-selecting validation-summary helper are no longer supported root APIs; use the Tokio sampler startup errors and the two purpose-specific validation summary functions.
+
 - Split direct shutdown failures into `ShutdownError::UnfinishedRequests` and
   `ShutdownError::Sink`, narrowing `SinkError` to sink-produced failures. Consolidated controller
   `DisableError`/`ShutdownError` into `GenerationFinalizationError`, renamed status

--- a/demos/collector_stress/src/main.rs
+++ b/demos/collector_stress/src/main.rs
@@ -365,8 +365,8 @@ fn build_instrumentation(cli: &Cli) -> anyhow::Result<Instrumentation> {
 
     let mut builder = Tailtriage::builder("collector_stress_demo").output(artifact_path.clone());
     builder = match capture_mode {
-        CaptureMode::Light => builder.light(),
-        CaptureMode::Investigation => builder.investigation(),
+        CaptureMode::Light => builder.mode(CaptureMode::Light),
+        CaptureMode::Investigation => builder.mode(CaptureMode::Investigation),
     };
 
     let tailtriage = Arc::new(builder.build()?);

--- a/demos/demo_support/src/lib.rs
+++ b/demos/demo_support/src/lib.rs
@@ -312,7 +312,7 @@ impl DemoInstrumentation {
     {
         match &self.backend {
             DemoInstrumentationBackend::Native(tailtriage) => {
-                let started = tailtriage.begin_request_with_owned(
+                let started = tailtriage.begin_owned_request_with(
                     route,
                     tailtriage_core::RequestOptions::new().request_id(request_id.clone()),
                 );
@@ -423,7 +423,7 @@ impl RuntimeDemoInstrumentation {
     {
         match &self.backend {
             RuntimeDemoBackend::Native(tailtriage) => {
-                let started = tailtriage.begin_request_with_owned(
+                let started = tailtriage.begin_owned_request_with(
                     route,
                     tailtriage_core::RequestOptions::new().request_id(request_id.clone()),
                 );
@@ -570,8 +570,8 @@ pub fn init_collector(
 ) -> anyhow::Result<Arc<Tailtriage>> {
     let mut builder = Tailtriage::builder(service_name).output(output_path);
     builder = match capture.mode {
-        CaptureMode::Light => builder.light(),
-        CaptureMode::Investigation => builder.investigation(),
+        CaptureMode::Light => builder.mode(CaptureMode::Light),
+        CaptureMode::Investigation => builder.mode(CaptureMode::Investigation),
     };
     if capture.max_requests.is_some()
         || capture.max_stages.is_some()
@@ -733,7 +733,7 @@ mod tests {
     fn sample_run_without_requests() -> Run {
         RunBuilder::new(RunBuilderOptions::new("demo-service"))
             .expect("build run")
-            .finish()
+            .build()
     }
 
     fn sample_run_with_one_request() -> Run {
@@ -751,7 +751,7 @@ mod tests {
                 outcome: Outcome::Ok.into_string(),
             })
             .expect("push request");
-        builder.finish()
+        builder.build()
     }
 
     fn unique_temp_output_path(prefix: &str) -> std::path::PathBuf {

--- a/demos/runtime_cost/src/main.rs
+++ b/demos/runtime_cost/src/main.rs
@@ -249,8 +249,8 @@ fn build_backend(cli: &Cli) -> anyhow::Result<Backend> {
             let sink = MemorySink::new();
             let mut b = Tailtriage::builder("runtime_cost_demo").sink(sink.clone());
             b = match mode {
-                CaptureMode::Light => b.light(),
-                CaptureMode::Investigation => b.investigation(),
+                CaptureMode::Light => b.mode(CaptureMode::Light),
+                CaptureMode::Investigation => b.mode(CaptureMode::Investigation),
             };
             if cli.mode.uses_drop_path_limits() {
                 b = b.capture_limits_override(CaptureLimitsOverride {

--- a/scripts/check_package_consumer.py
+++ b/scripts/check_package_consumer.py
@@ -100,7 +100,7 @@ def consumer_source() -> str:
 use tailtriage_analyzer::AnalyzeOptions;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let capture = Tailtriage::builder("package-consumer").build()?;
+    let capture = Tailtriage::builder("package-consumer").sink(tailtriage::DiscardSink).build()?;
     let started = capture.begin_request("/package-consumer");
     started.completion.finish_ok();
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -15,6 +15,23 @@ import validate_docs_contracts
 
 class ValidateDocsContractsTests(unittest.TestCase):
 
+    def _write_residual_api_sources(self, root: Path, overrides: dict[str, str] | None = None) -> None:
+        sources = {
+            'tailtriage-controller/src/lib.rs': 'pub fn begin_request() {}\n',
+            'tailtriage-tokio/src/lib.rs': 'pub fn builder() {}\n',
+            'tailtriage-axum/src/lib.rs': 'pub fn middleware() {}\n',
+            'tailtriage-cli/src/lib.rs': '#![doc = include_str!("../README.md")]\n',
+            'tailtriage-core/src/config.rs': '',
+            'tailtriage-core/src/collector.rs': '',
+            'tailtriage-core/src/run_builder.rs': '',
+            'tailtriage-core/src/lib.rs': '',
+        }
+        sources.update(overrides or {})
+        for rel, body in sources.items():
+            path = root / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(body, encoding='utf-8')
+
     # TT-TEST: Z02 primary
     def test_actual_repository_manual_release_boundary_is_non_mutating(self) -> None:
         validate_docs_contracts.validate_manual_release_boundary()
@@ -48,11 +65,11 @@ class ValidateDocsContractsTests(unittest.TestCase):
     def test_residual_public_api_cleanup_contract_accepts_private_cli_internals(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
-            sources = {'tailtriage-controller/src/lib.rs': 'pub fn begin_request() {}\n', 'tailtriage-tokio/src/lib.rs': 'pub fn builder() {}\n', 'tailtriage-axum/src/lib.rs': 'pub fn middleware() {}\n', 'tailtriage-cli/src/lib.rs': '#![doc = include_str!("../README.md")]\n'}
-            for rel, body in sources.items():
-                path = root / rel
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(body, encoding='utf-8')
+            self._write_residual_api_sources(root, {
+                'tailtriage-core/src/collector.rs': 'pub(crate) enum RuntimeSamplerRegistrationError {}\n',
+                'tailtriage-core/src/lib.rs': 'pub mod __internal { pub fn register_tokio_runtime_sampler() {} }\n',
+                'tailtriage-core/src/validation.rs': 'enum RunValidationSummaryAudience {}\nfn summarize_normalized_run() {}\n',
+            })
             with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
                 validate_docs_contracts.validate_residual_public_api_cleanup()
 
@@ -60,13 +77,39 @@ class ValidateDocsContractsTests(unittest.TestCase):
     def test_residual_public_api_cleanup_contract_rejects_cli_helper_export(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             root = Path(tmp_dir)
-            sources = {'tailtriage-controller/src/lib.rs': '', 'tailtriage-tokio/src/lib.rs': '', 'tailtriage-axum/src/lib.rs': '', 'tailtriage-cli/src/lib.rs': 'pub fn build_analyze_options() {}\n'}
-            for rel, body in sources.items():
-                path = root / rel
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_text(body, encoding='utf-8')
+            self._write_residual_api_sources(root, {
+                'tailtriage-cli/src/lib.rs': 'pub fn build_analyze_options() {}\n',
+            })
             with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
                 with self.assertRaisesRegex(ValueError, 'removed residual public API'):
+                    validate_docs_contracts.validate_residual_public_api_cleanup()
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_rejects_removed_builder_method(self) -> None:
+        self._assert_residual_api_rejected('tailtriage-core/src/config.rs', 'pub fn light(self) -> Self { self }', 'TailtriageBuilder::light')
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_rejects_removed_owned_request_method(self) -> None:
+        self._assert_residual_api_rejected('tailtriage-core/src/collector.rs', 'pub fn begin_request_owned(&self) {}', 'Tailtriage::begin_request_owned')
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_rejects_run_builder_finish(self) -> None:
+        self._assert_residual_api_rejected('tailtriage-core/src/run_builder.rs', 'pub fn finish(self) -> Run { todo!() }', 'RunBuilder::finish')
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_rejects_core_root_type_export(self) -> None:
+        self._assert_residual_api_rejected('tailtriage-core/src/lib.rs', 'pub use collector::{Tailtriage, RuntimeSamplerRegistrationError};', 'RuntimeSamplerRegistrationError')
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_rejects_core_root_function_export(self) -> None:
+        self._assert_residual_api_rejected('tailtriage-core/src/lib.rs', 'pub use validation::summarize_normalized_run;', 'summarize_normalized_run')
+
+    def _assert_residual_api_rejected(self, rel: str, source: str, symbol: str) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            self._write_residual_api_sources(root, {rel: source})
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
+                with self.assertRaisesRegex(ValueError, symbol):
                     validate_docs_contracts.validate_residual_public_api_cleanup()
 
     # TT-TEST: M02 primary

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -485,6 +485,42 @@ def validate_residual_public_api_cleanup() -> None:
                     f"{path.relative_to(REPO_ROOT)} exposes removed residual public API: {symbol}"
                 )
 
+    forbidden_public_patterns = {
+        REPO_ROOT / "tailtriage-core" / "src" / "config.rs": (
+            ("TailtriageBuilder::light", r"\bpub\s+fn\s+light\s*\("),
+            ("TailtriageBuilder::investigation", r"\bpub\s+fn\s+investigation\s*\("),
+        ),
+        REPO_ROOT / "tailtriage-core" / "src" / "collector.rs": (
+            ("Tailtriage::selected_mode", r"\bpub\s+(?:const\s+)?fn\s+selected_mode\s*\("),
+            ("Tailtriage::begin_request_owned", r"\bpub\s+fn\s+begin_request_owned\s*\("),
+            ("Tailtriage::begin_request_with_owned", r"\bpub\s+fn\s+begin_request_with_owned\s*\("),
+        ),
+        REPO_ROOT / "tailtriage-core" / "src" / "run_builder.rs": (
+            ("RunBuilder::finish", r"\bpub\s+fn\s+finish\s*\([^)]*\)\s*->\s*Run\b"),
+        ),
+        REPO_ROOT / "tailtriage-core" / "src" / "lib.rs": (
+            (
+                "RuntimeSamplerRegistrationError",
+                r"\bpub\s+use\s+collector\s*::\s*(?:[^;]*\bRuntimeSamplerRegistrationError\b)",
+            ),
+            (
+                "RunValidationSummaryAudience",
+                r"\bpub\s+use\s+validation\s*::\s*(?:[^;]*\bRunValidationSummaryAudience\b)",
+            ),
+            (
+                "summarize_normalized_run",
+                r"\bpub\s+use\s+validation\s*::\s*(?:[^;]*\bsummarize_normalized_run\b)",
+            ),
+        ),
+    }
+    for path, forbidden in forbidden_public_patterns.items():
+        text = path.read_text(encoding="utf-8")
+        for symbol, pattern in forbidden:
+            if re.search(pattern, text, re.DOTALL):
+                raise ValueError(
+                    f"{path.relative_to(REPO_ROOT)} exposes removed residual public API: {symbol}"
+                )
+
 
 def find_public_sampler_forge_methods(source: str) -> list[str]:
     return re.findall(r"^\s*pub\s+fn\s+([A-Za-z0-9_]*sampler[A-Za-z0-9_]*)\s*\(", source, re.MULTILINE)

--- a/tailtriage-axum/src/lib.rs
+++ b/tailtriage-axum/src/lib.rs
@@ -69,7 +69,7 @@ where
     C: Fn(StatusCode) -> Outcome,
 {
     let route = request_route_label(&request);
-    let started = tailtriage.begin_request_with_owned(route, RequestOptions::new().kind("http"));
+    let started = tailtriage.begin_owned_request_with(route, RequestOptions::new().kind("http"));
 
     request
         .extensions_mut()

--- a/tailtriage-axum/tests/axum_adapter.rs
+++ b/tailtriage-axum/tests/axum_adapter.rs
@@ -119,6 +119,7 @@ async fn middleware_injects_request_handle_and_finishes_from_response_status() {
 async fn middleware_records_default_http_outcomes_in_snapshot() {
     let tailtriage = Arc::new(
         Tailtriage::builder("axum-adapter-outcomes-test")
+            .sink(tailtriage_core::DiscardSink)
             .build()
             .expect("build should succeed"),
     );
@@ -179,6 +180,7 @@ async fn middleware_records_default_http_outcomes_in_snapshot() {
 async fn configurable_middleware_classifier_changes_recorded_outcome() {
     let tailtriage = Arc::new(
         Tailtriage::builder("axum-adapter-custom-classifier-test")
+            .sink(tailtriage_core::DiscardSink)
             .build()
             .expect("build should succeed"),
     );

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -511,6 +511,7 @@ fn canonical_tracing_conversion_matches_core_for_supported_cases() {
 #[test]
 fn native_run_is_strict_valid_and_normalization_idempotent() {
     let tailtriage = Tailtriage::builder("native-svc")
+        .sink(tailtriage_core::DiscardSink)
         .build()
         .expect("tailtriage should build");
     let started = tailtriage.begin_request_with(
@@ -566,6 +567,7 @@ fn native_run_is_strict_valid_and_normalization_idempotent() {
 #[test]
 fn native_derived_missing_precision_keeps_duration_evidence_without_lifecycle_mutation() {
     let tailtriage = Tailtriage::builder("native-svc")
+        .sink(tailtriage_core::DiscardSink)
         .build()
         .expect("tailtriage should build");
     let started = tailtriage.begin_request_with(

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -150,11 +150,8 @@ impl TailtriageControllerBuilder {
             },
             loaded,
         )
-        .map_err(|error| match error {
-            BuildError::EmptyServiceName => ControllerBuildError::EmptyServiceName,
-            BuildError::InvalidFinalizationTime { .. } => {
-                unreachable!("pure controller template validation does not validate timestamps")
-            }
+        .map_err(|ControllerTemplateError::EmptyServiceName| {
+            ControllerBuildError::EmptyServiceName
         })?;
 
         let inner = Arc::new(ControllerInner {
@@ -192,10 +189,27 @@ struct ResolvedControllerTemplate {
     public: TailtriageControllerTemplate,
 }
 
+/// Errors emitted by controller activation-template validation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ControllerTemplateError {
+    /// Service name was empty.
+    EmptyServiceName,
+}
+
+impl std::fmt::Display for ControllerTemplateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyServiceName => write!(f, "service_name cannot be empty"),
+        }
+    }
+}
+
+impl std::error::Error for ControllerTemplateError {}
+
 fn resolve_controller_template(
     mut template: TailtriageControllerTemplate,
     loaded: Option<LoadedControllerConfig>,
-) -> Result<ResolvedControllerTemplate, BuildError> {
+) -> Result<ResolvedControllerTemplate, ControllerTemplateError> {
     if let Some(loaded) = loaded {
         template.service_name = loaded.service_name.unwrap_or(template.service_name);
         let activation = loaded.activation_template;
@@ -207,7 +221,7 @@ fn resolve_controller_template(
         template.run_end_policy = activation.run_end_policy;
     }
     if template.service_name.trim().is_empty() {
-        return Err(BuildError::EmptyServiceName);
+        return Err(ControllerTemplateError::EmptyServiceName);
     }
     Ok(ResolvedControllerTemplate { public: template })
 }
@@ -529,8 +543,8 @@ impl TailtriageController {
             .output(&artifact_path);
 
         builder = match template.selected_mode {
-            CaptureMode::Light => builder.light(),
-            CaptureMode::Investigation => builder.investigation(),
+            CaptureMode::Light => builder.mode(CaptureMode::Light),
+            CaptureMode::Investigation => builder.mode(CaptureMode::Investigation),
         };
         builder = builder.capture_limits_override(template.capture_limits_override);
         builder = builder.strict_lifecycle(template.strict_lifecycle);
@@ -747,7 +761,7 @@ impl TailtriageController {
                         // this gate.
                         let _refused = active
                             .run
-                            .begin_request_with_owned(route.clone(), options.clone());
+                            .begin_owned_request_with(route.clone(), options.clone());
                     } else {
                         // Admission is linearized with every controller closure path by the
                         // generation admission gate. The core pair is created before the
@@ -755,7 +769,7 @@ impl TailtriageController {
                         // the caller until both steps complete.
                         let started = active
                             .run
-                            .begin_request_with_owned(route.clone(), options.clone());
+                            .begin_owned_request_with(route.clone(), options.clone());
                         // Request capacity is monotonic for a run: pending requests become
                         // retained requests without releasing a slot. Controller-owned
                         // production admissions are serialized here, while core independently
@@ -1774,7 +1788,7 @@ pub enum ReloadConfigError {
     /// Loading/parsing TOML config failed.
     Load(ConfigLoadError),
     /// Parsed config produced an invalid activation template.
-    Validate(BuildError),
+    Validate(ControllerTemplateError),
 }
 
 impl std::fmt::Display for ReloadConfigError {
@@ -1808,7 +1822,7 @@ pub enum ReloadTemplateError {
     /// The controller has entered its terminal shutdown state.
     ControllerShutdown,
     /// Template failed controller-owned validation.
-    Validate(BuildError),
+    Validate(ControllerTemplateError),
 }
 
 impl std::fmt::Display for ReloadTemplateError {
@@ -4219,7 +4233,7 @@ output_path = "C:\\Users\\someone\\AppData\\Local\\Temp\\tailtriage.json"
         assert!(matches!(
             controller.reload_template(invalid),
             Err(ReloadTemplateError::Validate(
-                super::BuildError::EmptyServiceName
+                super::ControllerTemplateError::EmptyServiceName
             ))
         ));
         assert_eq!(controller.status(), before);
@@ -4306,7 +4320,7 @@ kind = "continue_after_limits_hit"
         assert!(matches!(
             controller.reload_config(),
             Err(ReloadConfigError::Validate(
-                super::BuildError::EmptyServiceName
+                super::ControllerTemplateError::EmptyServiceName
             ))
         ));
         assert_eq!(controller.status(), before);

--- a/tailtriage-core/README.md
+++ b/tailtriage-core/README.md
@@ -29,6 +29,8 @@ Use `tailtriage` when you want the recommended default entry point: an aggregato
 cargo add tailtriage-core
 ```
 
+Direct capture requires an explicit output strategy: choose `.output(...)` for a persisted artifact, `.sink(MemorySink)` for in-memory inspection, or `.sink(DiscardSink)` when output is intentionally discarded. A bare builder returns `BuildError::MissingSink`; it never writes to the current directory implicitly.
+
 ## Quick start
 
 ```rust,no_run
@@ -54,7 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - `started.handle` for queue/stage/inflight instrumentation
 - `started.completion` for explicit finish
 
-For `Arc<Tailtriage>` flows that move request handles across spawned tasks or helper layers, use `begin_request_owned(...)` / `begin_request_with_owned(...)`. Owned handles keep the same lifecycle rule: instrumentation does not finish the request, and the completion token must be finished exactly once.
+For `Arc<Tailtriage>` flows that move request handles across spawned tasks or helper layers, use `begin_owned_request(...)` / `begin_owned_request_with(...)`. Owned handles keep the same lifecycle rule: instrumentation does not finish the request, and the completion token must be finished exactly once.
 
 ```rust,no_run
 use tailtriage_core::{RequestOptions, Tailtriage};
@@ -207,7 +209,7 @@ fn assemble_run() -> Result<(), Box<dyn std::error::Error>> {
         outcome: "ok".into(),
     })?;
 
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.requests.len(), 1);
     Ok(())
 }

--- a/tailtriage-core/src/collector.rs
+++ b/tailtriage-core/src/collector.rs
@@ -203,7 +203,9 @@ pub struct OwnedStartedRequest {
 /// use tailtriage_core::Tailtriage;
 ///
 /// # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
-/// let run = Tailtriage::builder("checkout-service").build()?;
+/// let run = Tailtriage::builder("checkout-service")
+///     .output("tailtriage-run.json")
+///     .build()?;
 /// let started = run.begin_request("/checkout");
 ///
 /// started.handle.queue("checkout_queue").await_on(async {}).await;
@@ -269,7 +271,7 @@ pub struct OwnedRequestCompletion {
 
 /// Error returned when registering Tokio runtime sampler metadata.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RuntimeSamplerRegistrationError {
+pub(crate) enum RuntimeSamplerRegistrationError {
     /// A runtime sampler was already registered for this run.
     DuplicateStart,
 }
@@ -306,7 +308,9 @@ impl Tailtriage {
 
         Ok(Self {
             state: CollectorStateCell::new(run),
-            sink: config.sink,
+            sink: config
+                .sink
+                .expect("builder validates explicit sink selection"),
             mode: config.mode,
             effective_core_config: config.effective_core,
             limits: config.effective_core.capture_limits,
@@ -319,7 +323,7 @@ impl Tailtriage {
 
     /// Returns the selected capture mode for this run.
     #[must_use]
-    pub const fn selected_mode(&self) -> crate::CaptureMode {
+    pub const fn capture_mode(&self) -> crate::CaptureMode {
         self.mode
     }
 
@@ -371,14 +375,14 @@ impl Tailtriage {
     ///
     /// This is the owned variant for fractured code paths that need to move
     /// handles across task boundaries.
-    pub fn begin_request_owned(self: &Arc<Self>, route: impl Into<String>) -> OwnedStartedRequest {
-        self.begin_request_with_owned(route, RequestOptions::new())
+    pub fn begin_owned_request(self: &Arc<Self>, route: impl Into<String>) -> OwnedStartedRequest {
+        self.begin_owned_request_with(route, RequestOptions::new())
     }
 
     /// Starts a request with caller-provided options using `Arc<Tailtriage>`.
     ///
     /// Finish the returned completion token exactly once.
-    pub fn begin_request_with_owned(
+    pub fn begin_owned_request_with(
         self: &Arc<Self>,
         route: impl Into<String>,
         options: RequestOptions,
@@ -515,10 +519,13 @@ impl Tailtriage {
         }
     }
 
-    /// Registers or clears a callback fired on the first transition to `limits_hit`.
+    /// Registers or clears the callback fired synchronously on the first `false` to `true`
+    /// `limits_hit` transition.
     ///
-    /// The callback is invoked at most once per run, exactly when truncation first
-    /// transitions from `false` to `true`.
+    /// At most one listener is installed. `None` clears it, and replacing a listener after
+    /// the transition does not replay that earlier transition. The callback runs inline with
+    /// capture-limit handling; it must not perform re-entrant lifecycle operations or other
+    /// behavior that could deadlock or violate lifecycle safety.
     ///
     /// # Panics
     ///

--- a/tailtriage-core/src/config.rs
+++ b/tailtriage-core/src/config.rs
@@ -173,7 +173,7 @@ pub(crate) struct Config {
     pub service_version: Option<String>,
     pub run_id: Option<String>,
     pub mode: CaptureMode,
-    pub sink: Arc<dyn RunSink + Send + Sync>,
+    pub sink: Option<Arc<dyn RunSink + Send + Sync>>,
     pub effective_core: EffectiveCoreConfig,
     pub strict_lifecycle: bool,
 }
@@ -196,7 +196,7 @@ impl Config {
             service_version: builder.service_version.clone(),
             run_id: builder.run_id.clone(),
             mode: builder.mode,
-            sink: Arc::clone(&builder.sink),
+            sink: builder.sink.clone(),
             effective_core,
             strict_lifecycle: builder.strict_lifecycle,
         }
@@ -208,26 +208,15 @@ impl Config {
 pub enum BuildError {
     /// Service name was empty.
     EmptyServiceName,
-    /// Finalization timestamp was earlier than start timestamp.
-    InvalidFinalizationTime {
-        /// Start timestamp in unix milliseconds.
-        started_at_unix_ms: u64,
-        /// Finalization timestamp in unix milliseconds.
-        finalized_at_unix_ms: u64,
-    },
+    /// No output path or custom sink was selected.
+    MissingSink,
 }
 
 impl std::fmt::Display for BuildError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EmptyServiceName => write!(f, "service_name cannot be empty"),
-            Self::InvalidFinalizationTime {
-                started_at_unix_ms,
-                finalized_at_unix_ms,
-            } => write!(
-                f,
-                "invalid finalization timestamp: finalized_at_unix_ms ({finalized_at_unix_ms}) must be >= started_at_unix_ms ({started_at_unix_ms})"
-            ),
+            Self::MissingSink => write!(f, "an output path or sink must be selected"),
         }
     }
 }
@@ -241,7 +230,7 @@ pub struct TailtriageBuilder {
     pub(crate) service_version: Option<String>,
     pub(crate) run_id: Option<String>,
     pub(crate) mode: CaptureMode,
-    pub(crate) sink: Arc<dyn RunSink + Send + Sync>,
+    pub(crate) sink: Option<Arc<dyn RunSink + Send + Sync>>,
     pub(crate) capture_limits: Option<CaptureLimits>,
     pub(crate) capture_limits_override: CaptureLimitsOverride,
     pub(crate) strict_lifecycle: bool,
@@ -254,37 +243,26 @@ impl TailtriageBuilder {
             service_version: None,
             run_id: None,
             mode: CaptureMode::Light,
-            sink: Arc::new(LocalJsonSink::new("tailtriage-run.json")),
+            sink: None,
             capture_limits: None,
             capture_limits_override: CaptureLimitsOverride::default(),
             strict_lifecycle: false,
         }
     }
 
-    /// Sets capture mode to [`CaptureMode::Light`].
-    ///
-    /// Light mode is the default and favors lower runtime cost in core-only capture categories with enough signal for first-pass triage.
+    /// Sets the capture mode. [`CaptureMode::Light`] is the default.
     #[must_use]
-    pub fn light(mut self) -> Self {
-        self.mode = CaptureMode::Light;
-        self
-    }
-
-    /// Sets capture mode to [`CaptureMode::Investigation`].
-    ///
-    /// Use this mode when you need more detailed evidence during an incident.
-    #[must_use]
-    pub fn investigation(mut self) -> Self {
-        self.mode = CaptureMode::Investigation;
+    pub fn mode(mut self, mode: CaptureMode) -> Self {
+        self.mode = mode;
         self
     }
 
     /// Writes run output to a local JSON file sink at `output_path`.
     ///
-    /// The default output path is `tailtriage-run.json`.
+    /// An output path or custom sink must be selected before [`Self::build`].
     #[must_use]
     pub fn output(mut self, output_path: impl AsRef<Path>) -> Self {
-        self.sink = Arc::new(LocalJsonSink::new(output_path));
+        self.sink = Some(Arc::new(LocalJsonSink::new(output_path)));
         self
     }
 
@@ -294,7 +272,7 @@ impl TailtriageBuilder {
     where
         S: RunSink + Send + Sync + 'static,
     {
-        self.sink = Arc::new(sink);
+        self.sink = Some(Arc::new(sink));
         self
     }
 
@@ -347,7 +325,15 @@ impl TailtriageBuilder {
     /// # Errors
     ///
     /// Returns [`BuildError::EmptyServiceName`] when the configured service name is blank.
+    /// Returns [`BuildError::MissingSink`] when neither [`Self::output`] nor [`Self::sink`]
+    /// was selected.
     pub fn build(self) -> Result<crate::Tailtriage, BuildError> {
+        if self.service_name.trim().is_empty() {
+            return Err(BuildError::EmptyServiceName);
+        }
+        if self.sink.is_none() {
+            return Err(BuildError::MissingSink);
+        }
         crate::Tailtriage::from_config(Config::from_builder(&self))
     }
 }

--- a/tailtriage-core/src/events.rs
+++ b/tailtriage-core/src/events.rs
@@ -81,7 +81,10 @@ pub struct Run {
 }
 
 impl Run {
-    /// Creates an empty run with the provided metadata.
+    /// Creates a raw, empty Run data model with the provided metadata.
+    ///
+    /// This constructor does not validate a completed artifact. Use [`crate::RunBuilder`] as
+    /// the canonical advanced path for assembling completed artifacts.
     #[must_use]
     pub fn new(metadata: RunMetadata) -> Self {
         Self {

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -41,7 +41,7 @@ mod validation;
 pub use artifact::{decode_run_json_path, RunJsonDecodeError};
 pub use collector::{
     OwnedRequestCompletion, OwnedRequestHandle, OwnedStartedRequest, RequestCompletion,
-    RequestHandle, RuntimeSamplerRegistrationError, ShutdownError, StartedRequest, Tailtriage,
+    RequestHandle, ShutdownError, StartedRequest, Tailtriage,
 };
 pub use config::{
     BuildError, CaptureLimits, CaptureLimitsOverride, CaptureMode, EffectiveCoreConfig,
@@ -52,24 +52,26 @@ pub use events::{
     RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, TruncationSummary,
     UnfinishedRequestSample, UnfinishedRequests, SCHEMA_VERSION,
 };
-pub use run_builder::{RunBuilder, RunBuilderEventError, RunBuilderOptions};
+pub use run_builder::{RunBuilder, RunBuilderError, RunBuilderEventError, RunBuilderOptions};
 pub use sink::{DiscardSink, LocalJsonSink, MemorySink, RunSink, SinkError};
 pub use time::{system_time_to_unix_ms, unix_time_ms};
 pub use timers::{InflightGuard, QueueTimer, StageTimer};
 pub use validation::{
-    inspect_run, normalize_run_permissive, summarize_normalized_run, summarize_run_validation,
+    inspect_run, normalize_run_permissive, summarize_run_validation,
     summarize_run_validation_lifecycle, validate_run_strict, NormalizedRun, RunEventDisposition,
     RunEventDispositionKind, RunSection, RunValidationError, RunValidationIssue,
     RunValidationIssueCode, RunValidationLocation, RunValidationReport, RunValidationSeverity,
-    RunValidationSummaryAudience, RUN_RELATIVE_DURATION_TOLERANCE_US,
+    RUN_RELATIVE_DURATION_TOLERANCE_US,
 };
 
 /// Internal integration hooks for sibling crates in this workspace.
 #[doc(hidden)]
 pub mod __internal {
-    use crate::{
-        EffectiveTokioSamplerConfig, RunEndReason, RuntimeSamplerRegistrationError, Tailtriage,
-    };
+    use crate::{EffectiveTokioSamplerConfig, RunEndReason, Tailtriage};
+
+    /// Internal duplicate-registration signal for the Tokio integration.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct DuplicateRuntimeSampler;
 
     /// Sets controller-owned run-end provenance without exposing live mutation publicly.
     pub fn set_run_end_reason_if_absent(tailtriage: &Tailtriage, reason: RunEndReason) {
@@ -101,13 +103,14 @@ pub mod __internal {
     ///
     /// # Errors
     ///
-    /// Returns [`RuntimeSamplerRegistrationError::DuplicateStart`] when a sampler
-    /// was already registered for this run.
+    /// Returns [`DuplicateRuntimeSampler`] when a sampler was already registered for this run.
     pub fn register_tokio_runtime_sampler(
         tailtriage: &Tailtriage,
         config: EffectiveTokioSamplerConfig,
-    ) -> Result<(), RuntimeSamplerRegistrationError> {
-        tailtriage.register_tokio_runtime_sampler(config)
+    ) -> Result<(), DuplicateRuntimeSampler> {
+        tailtriage
+            .register_tokio_runtime_sampler(config)
+            .map_err(|_| DuplicateRuntimeSampler)
     }
 
     #[cfg(test)]

--- a/tailtriage-core/src/run_builder.rs
+++ b/tailtriage-core/src/run_builder.rs
@@ -1,7 +1,7 @@
 use crate::{
-    collector::generate_run_id, unix_time_ms, BuildError, CaptureLimits, CaptureMode,
-    EffectiveCoreConfig, EffectiveTokioSamplerConfig, InFlightSnapshot, QueueEvent, RequestEvent,
-    Run, RunEndReason, RunMetadata, RuntimeSnapshot, StageEvent, UnfinishedRequests,
+    collector::generate_run_id, unix_time_ms, CaptureLimits, CaptureMode, EffectiveCoreConfig,
+    EffectiveTokioSamplerConfig, InFlightSnapshot, QueueEvent, RequestEvent, Run, RunEndReason,
+    RunMetadata, RuntimeSnapshot, StageEvent, UnfinishedRequests,
 };
 use core::fmt;
 
@@ -145,6 +145,34 @@ impl fmt::Display for RunBuilderEventError {
 
 impl std::error::Error for RunBuilderEventError {}
 
+/// Errors emitted while creating a completed-run builder.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunBuilderError {
+    /// Service name was empty.
+    EmptyServiceName,
+    /// Finalization timestamp was earlier than start timestamp.
+    InvalidFinalizationTime {
+        /// Start timestamp in unix milliseconds.
+        started_at_unix_ms: u64,
+        /// Finalization timestamp in unix milliseconds.
+        finalized_at_unix_ms: u64,
+    },
+}
+
+impl fmt::Display for RunBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyServiceName => write!(f, "service_name cannot be empty"),
+            Self::InvalidFinalizationTime { started_at_unix_ms, finalized_at_unix_ms } => write!(
+                f,
+                "invalid finalization timestamp: finalized_at_unix_ms ({finalized_at_unix_ms}) must be >= started_at_unix_ms ({started_at_unix_ms})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RunBuilderError {}
+
 /// Advanced/import API for completed-run artifact assembly.
 ///
 /// [`RunBuilder`] assembles a finalized [`Run`] from already measured evidence.
@@ -169,13 +197,13 @@ impl RunBuilder {
     ///
     /// # Errors
     ///
-    /// Returns [`BuildError::EmptyServiceName`] when the service name is blank.
+    /// Returns [`RunBuilderError::EmptyServiceName`] when the service name is blank.
     ///
-    /// Returns [`BuildError::InvalidFinalizationTime`] when finalization
+    /// Returns [`RunBuilderError::InvalidFinalizationTime`] when finalization
     /// timestamp is earlier than start timestamp.
-    pub fn new(options: RunBuilderOptions) -> Result<Self, BuildError> {
+    pub fn new(options: RunBuilderOptions) -> Result<Self, RunBuilderError> {
         if options.service_name.trim().is_empty() {
-            return Err(BuildError::EmptyServiceName);
+            return Err(RunBuilderError::EmptyServiceName);
         }
 
         let mode = options.mode.unwrap_or(CaptureMode::Light);
@@ -188,7 +216,7 @@ impl RunBuilder {
         let finalized_at_unix_ms = Some(finalized_at_unix_ms_value);
 
         if finalized_at_unix_ms_value < started_at_unix_ms {
-            return Err(BuildError::InvalidFinalizationTime {
+            return Err(RunBuilderError::InvalidFinalizationTime {
                 started_at_unix_ms,
                 finalized_at_unix_ms: finalized_at_unix_ms_value,
             });
@@ -286,14 +314,19 @@ impl RunBuilder {
     ///
     /// # Errors
     ///
-    /// Currently returns `Ok(())` for all runtime snapshots. The `Result`
-    /// keeps this API consistent with other [`RunBuilder`] push methods and
-    /// leaves room for future runtime snapshot validation without changing
-    /// the method shape.
+    /// Returns [`RunBuilderEventError`] when the snapshot has invalid intrinsic shape,
+    /// including a zero worker count.
     pub fn push_runtime_snapshot(
         &mut self,
         snapshot: RuntimeSnapshot,
     ) -> Result<(), RunBuilderEventError> {
+        if snapshot.worker_count == Some(0) {
+            return Err(invalid_event(
+                "RuntimeSnapshot",
+                "worker_count",
+                "must be greater than zero when present",
+            ));
+        }
         let _ = crate::retention::push_runtime_snapshot_bounded(
             &mut self.run,
             self.capture_limits,
@@ -324,7 +357,7 @@ impl RunBuilder {
     /// This does not perform lifecycle validation or synthesize missing
     /// completions.
     #[must_use]
-    pub fn finish(self) -> Run {
+    pub fn build(self) -> Run {
         let normalized = crate::normalize_run_permissive(&self.run);
         let warnings = crate::summarize_run_validation_lifecycle(&normalized);
         let mut run = normalized.run;

--- a/tailtriage-core/src/tests.rs
+++ b/tailtriage-core/src/tests.rs
@@ -4,8 +4,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::{
     BuildError, CaptureLimits, CaptureLimitsOverride, CaptureMode, EffectiveTokioSamplerConfig,
-    MemorySink, Outcome, RequestOptions, RuntimeSamplerRegistrationError, ShutdownError,
-    Tailtriage,
+    MemorySink, Outcome, RequestOptions, ShutdownError, Tailtriage,
 };
 
 #[derive(Debug, Default)]
@@ -32,9 +31,19 @@ fn build_for_test(name: &str, filename: &str) -> Tailtriage {
 #[test]
 fn rejects_blank_service_name() {
     let err = Tailtriage::builder("   ")
+        .sink(crate::DiscardSink)
         .build()
         .expect_err("blank service_name should fail");
     assert_eq!(err, BuildError::EmptyServiceName);
+}
+
+// TT-TEST: support
+#[test]
+fn rejects_missing_sink_selection() {
+    let err = Tailtriage::builder("payments")
+        .build()
+        .expect_err("output intent must be explicit");
+    assert_eq!(err, BuildError::MissingSink);
 }
 
 // TT-TEST: C01 primary
@@ -75,9 +84,11 @@ fn generated_request_ids_are_unique() {
 #[test]
 fn generated_default_run_ids_are_unique() {
     let first = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .build()
         .expect("first build should succeed");
     let second = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .build()
         .expect("second build should succeed");
 
@@ -91,6 +102,7 @@ fn generated_default_run_ids_are_unique() {
 #[test]
 fn active_snapshot_has_no_finalization_timestamp() {
     let tailtriage = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .build()
         .expect("build should succeed");
 
@@ -112,7 +124,7 @@ fn serialized_completed_run_uses_schema_v2_finalization_shape() {
             .finalized_at_unix_ms(2),
     )
     .expect("builder")
-    .finish();
+    .build();
     let serialized = serde_json::to_value(&run).expect("run serializes");
     assert_eq!(serialized["schema_version"], serde_json::json!(2));
     assert_eq!(
@@ -150,7 +162,7 @@ fn runtime_snapshot_worker_count_serde_is_optional_and_schema_v2_compatible() {
 fn serialized_run_has_no_metadata_finished_at_unix_ms() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
         .expect("builder")
-        .finish();
+        .build();
     let serialized = serde_json::to_value(&run).expect("run serializes");
     assert!(serialized["metadata"].get("finished_at_unix_ms").is_none());
 }
@@ -159,6 +171,7 @@ fn serialized_run_has_no_metadata_finished_at_unix_ms() {
 #[test]
 fn explicit_run_id_is_preserved() {
     let run = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .run_id("user-supplied-run-id")
         .build()
         .expect("build should succeed");
@@ -527,6 +540,7 @@ fn memory_sink_stores_finalized_run_after_shutdown() {
 fn memory_sink_last_run_returns_clone_without_clearing() {
     let sink = MemorySink::new();
     let mut run = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .build()
         .expect("build should succeed")
         .snapshot();
@@ -543,6 +557,7 @@ fn memory_sink_last_run_returns_clone_without_clearing() {
 fn memory_sink_take_run_returns_and_clears() {
     let sink = MemorySink::new();
     let run = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .build()
         .expect("build should succeed")
         .snapshot();
@@ -556,6 +571,7 @@ fn memory_sink_take_run_returns_and_clears() {
 fn memory_sink_clear_removes_stored_run() {
     let sink = MemorySink::new();
     let run = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .build()
         .expect("build should succeed")
         .snapshot();
@@ -593,6 +609,7 @@ fn capture_limits_apply_to_all_sections() {
         max_runtime_snapshots: 1,
     };
     let tailtriage = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .capture_limits(limits)
         .build()
         .expect("build should succeed");
@@ -660,7 +677,8 @@ fn capture_limits_remains_full_override() {
         max_runtime_snapshots: 50,
     };
     let tailtriage = Tailtriage::builder("payments")
-        .investigation()
+        .sink(crate::DiscardSink)
+        .mode(CaptureMode::Investigation)
         .capture_limits_override(CaptureLimitsOverride {
             max_requests: Some(999),
             ..CaptureLimitsOverride::default()
@@ -679,7 +697,8 @@ fn capture_limits_remains_full_override() {
 #[test]
 fn capture_limits_override_applies_selected_fields_on_mode_defaults() {
     let tailtriage = Tailtriage::builder("payments")
-        .investigation()
+        .sink(crate::DiscardSink)
+        .mode(CaptureMode::Investigation)
         .capture_limits_override(CaptureLimitsOverride {
             max_requests: Some(12_345),
             max_runtime_snapshots: Some(88),
@@ -698,12 +717,14 @@ fn capture_limits_override_applies_selected_fields_on_mode_defaults() {
 #[test]
 fn strict_lifecycle_is_unchanged_by_mode() {
     let light = Tailtriage::builder("payments")
-        .light()
+        .sink(crate::DiscardSink)
+        .mode(CaptureMode::Light)
         .strict_lifecycle(true)
         .build()
         .expect("build should succeed");
     let investigation = Tailtriage::builder("payments")
-        .investigation()
+        .sink(crate::DiscardSink)
+        .mode(CaptureMode::Investigation)
         .strict_lifecycle(true)
         .build()
         .expect("build should succeed");
@@ -716,7 +737,8 @@ fn strict_lifecycle_is_unchanged_by_mode() {
 #[test]
 fn selected_mode_and_effective_config_are_preserved_in_metadata() {
     let tailtriage = Tailtriage::builder("payments")
-        .investigation()
+        .sink(crate::DiscardSink)
+        .mode(CaptureMode::Investigation)
         .capture_limits_override(CaptureLimitsOverride {
             max_queues: Some(7),
             ..CaptureLimitsOverride::default()
@@ -725,7 +747,7 @@ fn selected_mode_and_effective_config_are_preserved_in_metadata() {
         .expect("build should succeed");
 
     let snapshot = tailtriage.snapshot();
-    assert_eq!(tailtriage.selected_mode(), CaptureMode::Investigation);
+    assert_eq!(tailtriage.capture_mode(), CaptureMode::Investigation);
     assert_eq!(snapshot.metadata.mode, CaptureMode::Investigation);
     assert_eq!(
         snapshot.metadata.effective_core_config,
@@ -746,6 +768,7 @@ fn selected_mode_and_effective_config_are_preserved_in_metadata() {
 #[test]
 fn runtime_sampler_registration_is_single_start_and_metadata_cannot_be_overwritten() {
     let tailtriage = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .build()
         .expect("build should succeed");
     let first = EffectiveTokioSamplerConfig {
@@ -769,7 +792,10 @@ fn runtime_sampler_registration_is_single_start_and_metadata_cannot_be_overwritt
     let err = tailtriage
         .register_tokio_runtime_sampler(second)
         .expect_err("duplicate registration should fail");
-    assert_eq!(err, RuntimeSamplerRegistrationError::DuplicateStart);
+    assert_eq!(
+        err,
+        crate::collector::RuntimeSamplerRegistrationError::DuplicateStart
+    );
 
     let snapshot = tailtriage.snapshot();
     assert_eq!(
@@ -782,6 +808,7 @@ fn runtime_sampler_registration_is_single_start_and_metadata_cannot_be_overwritt
 #[test]
 fn limit_hit_flag_is_set_when_truncation_occurs() {
     let tailtriage = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .capture_limits(CaptureLimits {
             max_requests: 1,
             max_stages: 1,
@@ -804,6 +831,7 @@ fn limit_hit_flag_is_set_when_truncation_occurs() {
 #[test]
 fn saturation_preserves_exact_drop_counts_across_sections() {
     let tailtriage = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .capture_limits(CaptureLimits {
             max_requests: 1,
             max_stages: 1,
@@ -1058,6 +1086,7 @@ fn shutdown_artifact_includes_post_saturation_drops() {
 #[test]
 fn unsaturated_runs_keep_zero_truncation_counters() {
     let tailtriage = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .capture_limits(CaptureLimits {
             max_requests: 10,
             max_stages: 10,
@@ -1100,11 +1129,13 @@ fn unsaturated_runs_keep_zero_truncation_counters() {
 #[test]
 fn mode_does_not_change_event_types_or_lifecycle_shape() {
     let light = Tailtriage::builder("payments")
-        .light()
+        .sink(crate::DiscardSink)
+        .mode(CaptureMode::Light)
         .build()
         .expect("build should succeed");
     let investigation = Tailtriage::builder("payments")
-        .investigation()
+        .sink(crate::DiscardSink)
+        .mode(CaptureMode::Investigation)
         .build()
         .expect("build should succeed");
 
@@ -1336,14 +1367,14 @@ fn owned_started_request_maps_result_to_request_outcome() {
     ));
 
     let ok_value = tailtriage
-        .begin_request_owned("/owned-result-ok")
+        .begin_owned_request("/owned-result-ok")
         .completion
         .finish_result(Ok::<u8, &'static str>(9))
         .expect("ok result should remain ok");
     assert_eq!(ok_value, 9);
 
     let err = tailtriage
-        .begin_request_owned("/owned-result-err")
+        .begin_owned_request("/owned-result-err")
         .completion
         .finish_result::<u8, _>(Err("boom"))
         .expect_err("err result should remain err");
@@ -1410,6 +1441,7 @@ fn shutdown_warns_with_unfinished_requests() {
 #[test]
 fn strict_lifecycle_fails_shutdown_with_unfinished_requests() {
     let tailtriage = Tailtriage::builder("payments")
+        .sink(crate::DiscardSink)
         .strict_lifecycle(true)
         .build()
         .expect("build should succeed");
@@ -1500,7 +1532,7 @@ fn run_builder_creates_empty_run_with_explicit_metadata() {
             outcome: "ok".into(),
         })
         .expect("ok");
-    let run = builder.finish();
+    let run = builder.build();
 
     assert_eq!(run.schema_version, crate::SCHEMA_VERSION);
     assert_eq!(run.metadata.service_name, "payments");
@@ -1530,7 +1562,7 @@ fn run_builder_creates_empty_run_with_explicit_metadata() {
 #[test]
 fn run_builder_rejects_blank_service_name() {
     let err = crate::RunBuilder::new(crate::RunBuilderOptions::new("  ")).expect_err("should fail");
-    assert_eq!(err, BuildError::EmptyServiceName);
+    assert_eq!(err, crate::RunBuilderError::EmptyServiceName);
 }
 
 // TT-TEST: support
@@ -1538,10 +1570,10 @@ fn run_builder_rejects_blank_service_name() {
 fn run_builder_default_run_ids_are_unique() {
     let first = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
         .expect("ok")
-        .finish();
+        .build();
     let second = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
         .expect("ok")
-        .finish();
+        .build();
     assert_ne!(first.metadata.run_id, second.metadata.run_id);
 }
 
@@ -1550,7 +1582,7 @@ fn run_builder_default_run_ids_are_unique() {
 fn run_builder_defaults_host_and_pid_to_none() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
         .expect("ok")
-        .finish();
+        .build();
     assert!(run.metadata.host.is_none());
     assert!(run.metadata.pid.is_none());
 }
@@ -1560,7 +1592,7 @@ fn run_builder_defaults_host_and_pid_to_none() {
 fn run_builder_defaults_start_and_finalization_from_one_timestamp() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
         .expect("ok")
-        .finish();
+        .build();
     assert_eq!(
         run.metadata.finalized_at_unix_ms,
         Some(run.metadata.started_at_unix_ms)
@@ -1576,7 +1608,7 @@ fn run_builder_preserves_explicit_start_and_finalization() {
             .finalized_at_unix_ms(777),
     )
     .expect("ok")
-    .finish();
+    .build();
     assert_eq!(run.metadata.started_at_unix_ms, 100);
     assert_eq!(run.metadata.finalized_at_unix_ms, Some(777));
 }
@@ -1586,7 +1618,7 @@ fn run_builder_preserves_explicit_start_and_finalization() {
 fn run_builder_preserves_explicit_start_with_default_finalization() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").started_at_unix_ms(100))
         .expect("ok")
-        .finish();
+        .build();
     assert!(run.metadata.finalized_at_unix_ms.expect("finalized") >= 100);
 }
 
@@ -1596,7 +1628,7 @@ fn run_builder_preserves_explicit_finalization_with_default_start() {
     let run =
         crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").finalized_at_unix_ms(u64::MAX))
             .expect("ok")
-            .finish();
+            .build();
     assert_eq!(run.metadata.finalized_at_unix_ms, Some(u64::MAX));
 }
 
@@ -1609,7 +1641,7 @@ fn run_builder_allows_equal_timestamp_bounds() {
             .finalized_at_unix_ms(100),
     )
     .expect("ok")
-    .finish();
+    .build();
 
     assert_eq!(run.metadata.started_at_unix_ms, 100);
     assert_eq!(run.metadata.finalized_at_unix_ms, Some(100));
@@ -1627,7 +1659,7 @@ fn run_builder_rejects_finalization_before_start() {
 
     assert_eq!(
         err,
-        BuildError::InvalidFinalizationTime {
+        crate::RunBuilderError::InvalidFinalizationTime {
             started_at_unix_ms: 100,
             finalized_at_unix_ms: 99
         }
@@ -1639,7 +1671,7 @@ fn run_builder_rejects_finalization_before_start() {
 fn run_builder_default_timestamps_produce_valid_finalized_run() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc"))
         .expect("ok")
-        .finish();
+        .build();
 
     assert!(run.metadata.finalized_at_unix_ms.is_some());
     assert!(
@@ -1652,7 +1684,7 @@ fn run_builder_default_timestamps_produce_valid_finalized_run() {
 fn run_builder_strict_lifecycle_in_effective_core_config() {
     let run = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc").strict_lifecycle(true))
         .expect("ok")
-        .finish();
+        .build();
     assert!(
         run.metadata
             .effective_core_config
@@ -1667,7 +1699,7 @@ fn run_builder_set_run_end_reason_if_absent_only_sets_once() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
     builder.set_run_end_reason_if_absent(crate::RunEndReason::Shutdown);
     builder.set_run_end_reason_if_absent(crate::RunEndReason::ManualDisarm);
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(
         run.metadata.run_end_reason,
         Some(crate::RunEndReason::Shutdown)
@@ -1680,7 +1712,7 @@ fn run_builder_preserves_lifecycle_warnings() {
     let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
     builder.add_lifecycle_warning("warning-1");
     builder.add_lifecycle_warning("warning-2");
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(
         run.metadata.lifecycle_warnings,
         vec!["warning-1", "warning-2"]
@@ -1698,7 +1730,7 @@ fn run_builder_preserves_unfinished_requests() {
             route: "/r".into(),
         }],
     });
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.metadata.unfinished_requests.count, 2);
     assert_eq!(run.metadata.unfinished_requests.sample.len(), 1);
 }
@@ -1764,7 +1796,7 @@ fn run_builder_applies_request_limit_and_updates_truncation() {
     builder
         .push_request(test_request_event("req-2"))
         .expect("ok");
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.requests[0].request_id, "req-1");
     assert_eq!(run.truncation.dropped_requests, 1);
@@ -1798,7 +1830,7 @@ fn run_builder_applies_stage_limit_and_updates_truncation() {
     builder
         .push_stage(test_stage_event("req-2", "stage-2"))
         .expect("ok");
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.stages.len(), 1);
     assert_eq!(run.stages[0].stage, "stage-1");
     assert_eq!(run.truncation.dropped_stages, 1);
@@ -1832,7 +1864,7 @@ fn run_builder_applies_queue_limit_and_updates_truncation() {
     builder
         .push_queue(test_queue_event("req-2", "queue-2"))
         .expect("ok");
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.queues.len(), 1);
     assert_eq!(run.queues[0].queue, "queue-1");
     assert_eq!(run.truncation.dropped_queues, 1);
@@ -1873,7 +1905,7 @@ fn run_builder_applies_inflight_snapshot_limit_and_updates_truncation() {
             count: 2,
         })
         .expect("ok");
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.inflight.len(), 1);
     assert_eq!(run.inflight[0].count, 1);
     assert_eq!(run.truncation.dropped_inflight_snapshots, 1);
@@ -1922,7 +1954,7 @@ fn run_builder_applies_runtime_snapshot_limit_and_updates_truncation() {
             remote_schedule_count: Some(6),
         })
         .expect("ok");
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.runtime_snapshots.len(), 1);
     assert_eq!(run.runtime_snapshots[0].at_unix_ms, 9);
     assert_eq!(run.truncation.dropped_runtime_snapshots, 1);
@@ -1976,7 +2008,7 @@ fn run_builder_does_not_report_truncation_within_limits() {
             remote_schedule_count: Some(1),
         })
         .expect("ok");
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.stages.len(), 1);
     assert_eq!(run.queues.len(), 1);
@@ -2003,7 +2035,7 @@ fn run_builder_uses_mode_default_limits_when_limits_not_explicit() {
             .push_request(test_request_event(&format!("req-{}", i + 1)))
             .expect("ok");
     }
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.requests.len(), default_limits.max_requests);
     assert_eq!(run.truncation.dropped_requests, 2);
     assert!(run.truncation.limits_hit);
@@ -2039,6 +2071,33 @@ fn run_builder_valid_pushes_return_ok() {
             remote_schedule_count: None,
         })
         .is_ok());
+}
+
+// TT-TEST: V04 secondary
+#[test]
+fn run_builder_rejects_zero_worker_count_before_retention() {
+    let mut builder = crate::RunBuilder::new(crate::RunBuilderOptions::new("svc")).expect("ok");
+    let err = builder
+        .push_runtime_snapshot(crate::RuntimeSnapshot {
+            at_unix_ms: 1,
+            at_run_us: None,
+            alive_tasks: None,
+            worker_count: Some(0),
+            global_queue_depth: None,
+            local_queue_depth: None,
+            blocking_queue_depth: None,
+            remote_schedule_count: None,
+        })
+        .expect_err("zero worker count is intrinsically invalid");
+    assert_eq!(
+        err,
+        crate::RunBuilderEventError::InvalidEvent {
+            event: "RuntimeSnapshot",
+            field: "worker_count",
+            reason: "must be greater than zero when present".into(),
+        }
+    );
+    assert!(builder.build().runtime_snapshots.is_empty());
 }
 
 // TT-TEST: support
@@ -2199,7 +2258,7 @@ fn run_builder_accepts_incomplete_run_relative_offsets() {
     queue.waited_until_run_us = None;
     builder.push_queue(queue).expect("queue accepted");
 
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.requests[0].started_at_run_us, None);
     assert_eq!(run.requests[0].finished_at_run_us, None);
     assert_eq!(run.stages[0].started_at_run_us, None);
@@ -2219,7 +2278,7 @@ fn run_builder_accepts_authoritative_request_latency_when_timestamps_disagree() 
     request.latency_us = 50_000;
 
     builder.push_request(request).expect("push should succeed");
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.requests.len(), 1);
     assert_eq!(run.requests[0].latency_us, 50_000);
 }
@@ -2238,7 +2297,7 @@ fn run_builder_accepts_authoritative_stage_latency_when_timestamps_disagree() {
     stage.latency_us = 50_000;
 
     builder.push_stage(stage).expect("push should succeed");
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.stages.len(), 1);
     assert_eq!(run.stages[0].latency_us, 50_000);
 }
@@ -2257,7 +2316,7 @@ fn run_builder_accepts_authoritative_queue_wait_when_timestamps_disagree() {
     queue.wait_us = 50_000;
 
     builder.push_queue(queue).expect("push should succeed");
-    let run = builder.finish();
+    let run = builder.build();
     assert_eq!(run.queues.len(), 1);
     assert_eq!(run.queues[0].wait_us, 50_000);
 }
@@ -2670,7 +2729,7 @@ mod run_validation_contract {
             .push_queue(queue("missing-queue-parent"))
             .expect("queue");
 
-        let run = builder.finish();
+        let run = builder.build();
 
         assert!(run.stages.is_empty());
         assert!(run.queues.is_empty());
@@ -3238,7 +3297,7 @@ fn owned_completion_drop_records_cancelled_request() {
             .expect("build"),
     );
     {
-        let started = tailtriage.begin_request_with_owned(
+        let started = tailtriage.begin_owned_request_with(
             "/owned-cancel",
             RequestOptions::new().request_id("req-owned").kind("job"),
         );
@@ -3400,7 +3459,7 @@ fn shutdown_wins_before_drop_keeps_request_unfinished_only() {
             .build()
             .expect("build"),
     );
-    let started = tailtriage.begin_request_with_owned(
+    let started = tailtriage.begin_owned_request_with(
         "/held",
         RequestOptions::new().request_id("req-held-unfinished"),
     );
@@ -4097,7 +4156,7 @@ mod prompt09_partial_events {
         assert!(poll_once(&mut fut).is_pending());
         drop(fut);
 
-        let owned_stage = tt.begin_request_with_owned(
+        let owned_stage = tt.begin_owned_request_with(
             "/r",
             RequestOptions::new().request_id("owned-stage-request"),
         );
@@ -4109,7 +4168,7 @@ mod prompt09_partial_events {
         assert!(poll_once(&mut fut).is_pending());
         drop(fut);
 
-        let owned_queue = tt.begin_request_with_owned(
+        let owned_queue = tt.begin_owned_request_with(
             "/r",
             RequestOptions::new().request_id("owned-queue-request"),
         );

--- a/tailtriage-core/src/time.rs
+++ b/tailtriage-core/src/time.rs
@@ -111,6 +111,9 @@ pub fn system_time_to_unix_ms(time: SystemTime) -> u64 {
 }
 
 /// Returns the current unix epoch timestamp in milliseconds.
+///
+/// A pre-epoch system clock is clamped to `0`; values too large for `u64` milliseconds
+/// saturate at [`u64::MAX`].
 #[must_use]
 pub fn unix_time_ms() -> u64 {
     system_time_to_unix_ms(SystemTime::now())

--- a/tailtriage-core/src/validation.rs
+++ b/tailtriage-core/src/validation.rs
@@ -213,7 +213,7 @@ pub fn normalize_run_permissive(run: &Run) -> NormalizedRun {
 
 /// Audience for canonical run validation summaries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum RunValidationSummaryAudience {
+enum RunValidationSummaryAudience {
     /// Analyzer-facing warnings include unchanged legacy precision limitations.
     Analyzer,
     /// Durable lifecycle warnings include only output-changing findings.
@@ -236,7 +236,7 @@ pub fn summarize_run_validation_lifecycle(normalized: &NormalizedRun) -> Vec<Str
 
 /// Returns bounded deterministic validation summaries for the selected audience.
 #[must_use]
-pub fn summarize_normalized_run(
+fn summarize_normalized_run(
     normalized: &NormalizedRun,
     audience: RunValidationSummaryAudience,
 ) -> Vec<String> {

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -82,7 +82,7 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
     let run = Arc::new(
         Tailtriage::builder("checkout-service")
             .output("tailtriage-run.json")
-            .investigation()
+            .mode(CaptureMode::Investigation)
             .build()?,
     );
 
@@ -186,7 +186,7 @@ use tailtriage_tokio::RuntimeSampler;
 # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 let run = Arc::new(
     Tailtriage::builder("checkout-service")
-        .light()
+        .mode(CaptureMode::Light)
         .output("tailtriage-run.json")
         .build()?,
 );
@@ -209,7 +209,7 @@ use tailtriage_tokio::RuntimeSampler;
 # async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 let run = Arc::new(
     Tailtriage::builder("checkout-service")
-        .investigation()
+        .mode(CaptureMode::Investigation)
         .output("tailtriage-run.json")
         .build()?,
 );

--- a/tailtriage-tokio/examples/mini_service_integration.rs
+++ b/tailtriage-tokio/examples/mini_service_integration.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use tailtriage_core::{RequestOptions, Tailtriage};
+use tailtriage_core::{CaptureMode, RequestOptions, Tailtriage};
 use tailtriage_tokio::RuntimeSampler;
 
 #[derive(Clone)]
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let tailtriage = Arc::new(
         Tailtriage::builder("mini-checkout-service")
             .output(output_path)
-            .investigation()
+            .mode(CaptureMode::Investigation)
             .build()?,
     );
     let requests = [

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -13,8 +13,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use tailtriage_core::{
-    __internal, unix_time_ms, CaptureMode, EffectiveTokioSamplerConfig,
-    RuntimeSamplerRegistrationError, RuntimeSnapshot, Tailtriage,
+    __internal, unix_time_ms, CaptureMode, EffectiveTokioSamplerConfig, RuntimeSnapshot, Tailtriage,
 };
 use tokio::runtime::Handle;
 use tokio::sync::oneshot;
@@ -582,9 +581,7 @@ impl RuntimeSamplerBuilder {
             &self.tailtriage,
             resolved.into_effective_metadata(),
         )
-        .map_err(|err| match err {
-            RuntimeSamplerRegistrationError::DuplicateStart => SamplerStartError::DuplicateStart,
-        })?;
+        .map_err(|__internal::DuplicateRuntimeSampler| SamplerStartError::DuplicateStart)?;
 
         let tailtriage = Arc::clone(&self.tailtriage);
         let (stop_tx, mut stop_rx) = oneshot::channel();
@@ -620,7 +617,7 @@ impl RuntimeSamplerBuilder {
     }
 
     fn resolve_config(&self) -> Result<ResolvedRuntimeSamplerConfig, SamplerStartError> {
-        let inherited_mode = self.tailtriage.selected_mode();
+        let inherited_mode = self.tailtriage.capture_mode();
         let resolved_mode = self.explicit_mode_override.unwrap_or(inherited_mode);
         let mode_defaults = TokioSamplerModeDefaults::for_mode(resolved_mode);
         let resolved_interval = self.interval_override.unwrap_or(mode_defaults.cadence);
@@ -819,7 +816,7 @@ mod tests {
         let tailtriage = Arc::new(
             Tailtriage::builder("runtime-test")
                 .output(std::env::temp_dir().join("tailtriage_tokio_inherit_light.json"))
-                .light()
+                .mode(CaptureMode::Light)
                 .build()
                 .expect("build should succeed"),
         );
@@ -852,7 +849,7 @@ mod tests {
         let tailtriage = Arc::new(
             Tailtriage::builder("runtime-test")
                 .output(std::env::temp_dir().join("tailtriage_tokio_inherit_investigation.json"))
-                .investigation()
+                .mode(CaptureMode::Investigation)
                 .build()
                 .expect("build should succeed"),
         );
@@ -885,7 +882,7 @@ mod tests {
         let tailtriage = Arc::new(
             Tailtriage::builder("runtime-test")
                 .output(std::env::temp_dir().join("tailtriage_tokio_mode_override.json"))
-                .light()
+                .mode(CaptureMode::Light)
                 .build()
                 .expect("build should succeed"),
         );
@@ -1085,7 +1082,7 @@ mod tests {
     async fn sampler_does_not_autostart_from_capture_mode() {
         let tailtriage = Tailtriage::builder("runtime-test")
             .output(std::env::temp_dir().join("tailtriage_tokio_no_autostart.json"))
-            .investigation()
+            .mode(CaptureMode::Investigation)
             .build()
             .expect("build should succeed");
 
@@ -1501,7 +1498,7 @@ mod helper_tests {
     #[tokio::test(flavor = "current_thread")]
     async fn owned_request_handle_works_and_helpers_do_not_finish_request() {
         let run = Arc::new(run());
-        let started = run.begin_request_owned("/owned");
+        let started = run.begin_owned_request("/owned");
         let owned = started.handle.clone();
         let sem = Arc::new(tokio::sync::Semaphore::new(1));
         let permit = owned
@@ -1758,7 +1755,7 @@ mod prompt09_tokio_partial_tests {
     #[tokio::test(flavor = "current_thread")]
     async fn owned_handle_stage_helper_pending_then_drop_records_partial_stage() {
         let tt = Arc::new(capture());
-        let started = tt.begin_request_owned("/r");
+        let started = tt.begin_owned_request("/r");
         let (tx, rx) = tokio::sync::oneshot::channel::<()>();
         let handle = tokio::spawn(async move {
             let _ = rx.await;

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -786,7 +786,7 @@ impl TracingSessionBuilder {
         if self.sampler_interval.is_none() && !self.manual_runtime_snapshots {
             return Ok(None);
         }
-        let mode = self.recorder_builder.selected_mode();
+        let mode = self.recorder_builder.capture_mode();
         let resolved_limits = self.recorder_builder.resolved_capture_limits();
         let sink = MemorySink::new();
         let builder = Tailtriage::builder("tailtriage-tracing-runtime")
@@ -794,8 +794,8 @@ impl TracingSessionBuilder {
             .strict_lifecycle(false)
             .capture_limits(resolved_limits);
         let builder = match mode {
-            CaptureMode::Light => builder.light(),
-            CaptureMode::Investigation => builder.investigation(),
+            CaptureMode::Light => builder.mode(CaptureMode::Light),
+            CaptureMode::Investigation => builder.mode(CaptureMode::Investigation),
         };
         let collector = builder.build().map_err(|err| ImportError::Io {
             operation: "build tracing Tokio runtime collector",
@@ -846,7 +846,7 @@ impl LiveRecorderBuilder {
     /// Returns selected capture mode for import conversion semantics.
     #[cfg(feature = "tokio")]
     #[must_use]
-    pub(crate) fn selected_mode(&self) -> CaptureMode {
+    pub(crate) fn capture_mode(&self) -> CaptureMode {
         self.options.mode_value()
     }
 

--- a/tailtriage-tracing/tests/support/equivalence_harness.rs
+++ b/tailtriage-tracing/tests/support/equivalence_harness.rs
@@ -229,7 +229,7 @@ pub fn build_native_case_with_limits(name: &str, limits: CaptureLimits) -> Run {
     for event in source.queues {
         builder.push_queue(event).unwrap();
     }
-    builder.finish()
+    builder.build()
 }
 
 pub fn expected_run(name: &str) -> RepresentableRunProjection {

--- a/tailtriage-tracing/tests/tracing_examples.rs
+++ b/tailtriage-tracing/tests/tracing_examples.rs
@@ -12,6 +12,7 @@ use tracing_subscriber::prelude::*;
 #[cfg(feature = "live")]
 fn native_single_request_run() -> Run {
     let tailtriage = Tailtriage::builder("svc")
+        .sink(tailtriage_core::DiscardSink)
         .build()
         .expect("native session should build");
     let started = tailtriage.begin_request_with(

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -41,7 +41,8 @@ mod tests {
     // TT-TEST: P01 primary
     #[test]
     fn core_reexport_exposes_tailtriage() {
-        let _builder = crate::Tailtriage::builder("default-smoke");
+        let _builder =
+            crate::Tailtriage::builder("default-smoke").sink(tailtriage_core::DiscardSink);
     }
 
     // TT-TEST: P01 primary
@@ -50,6 +51,7 @@ mod tests {
     fn tokio_namespace_reexport_compiles() {
         let _builder = crate::tokio::RuntimeSampler::builder(std::sync::Arc::new(
             crate::Tailtriage::builder("tokio-smoke")
+                .sink(tailtriage_core::DiscardSink)
                 .build()
                 .expect("build should succeed"),
         ));


### PR DESCRIPTION
### Motivation
- Remove the implicit persisted-output behavior from the core builder so callers must explicitly choose an output strategy and avoid surprising writes to CWD.
- Simplify and normalize builder ergonomics for capture mode, run assembly, owned-request naming, and runtime-sampler registration so the 0.4 public API is consistent and easier to migrate to.
- Separate live-build errors from completed-run assembly errors and move intrinsic runtime-snapshot shape validation earlier to improve error locality and fix edge-case semantics.

### Description
- Require explicit output/sink selection: `TailtriageBuilder` now requires either `.output(...)` or `.sink(...)` before `build()`; omission returns `BuildError::MissingSink` and the builder no longer implicitly writes `tailtriage-run.json`.
- Normalize capture-mode API and accessors: removed `.light()` / `.investigation()` in favor of `.mode(CaptureMode)`, and renamed `selected_mode()` to `capture_mode()`.
- Split run-construction errors and rename finish: introduced `RunBuilderError` (migrated `InvalidFinalizationTime` there), replaced `RunBuilder::finish()` with `RunBuilder::build()`, and updated `RunBuilder::new(...)` to return `RunBuilderError`.
- Early runtime-snapshot validation: `RunBuilder::push_runtime_snapshot(...)` now rejects intrinsically invalid shapes (at minimum `worker_count == Some(0)`) instead of repairing later.
- Owned-request grammar normalized: renamed `begin_request_owned` -> `begin_owned_request` and `begin_request_with_owned` -> `begin_owned_request_with` (no aliases retained).
- Internalized sampler registration and validation-summary helpers: `RuntimeSamplerRegistrationError` is now internal/private; public cross-crate registration helper maps to a doc-hidden internal duplicate-signal; `RunValidationSummaryAudience` and `summarize_normalized_run` were made implementation-private while keeping `summarize_run_validation` and `summarize_run_validation_lifecycle` public.
- Doc and surface updates: updated docs, READMEs, demos, examples, and tests to use explicit sink/output, `.mode(...)`, `capture_mode()`, owned-request names, and `RunBuilder::build()`; added rustdoc clarifications for retained APIs (`set_limits_hit_listener`, `Run::new`, time helpers).

### Testing
- Focused and workspace tests: ran and passed: `cargo test -p tailtriage-core`, `-p tailtriage-tokio`, `-p tailtriage-tracing`, `-p tailtriage-controller`, and `-p tailtriage` (all targets, all-features, locked).
- Validation and docs: ran `python3 scripts/validate_invariant_proofs.py`, `python3 scripts/validate_docs_contracts.py`, `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked` and they succeeded.
- Smoke and examples: `python3 scripts/smoke_public_examples.py` executed successfully.
- Tests added/changed: added a focused negative test proving `BuildError::MissingSink` and a `RunBuilder` test rejecting `worker_count == Some(0)` before retention; existing primary invariants (`C01`, `C02`, `V04`, `T03`, `P01`, `M02`) were preserved as syntax-only migrations or reclassified where the rejection point moved earlier (V04 semantics unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a95f8b2a91c8330b443cc65ce651b53)