### PR TITLE
api: make inflight trend direction explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- `InflightTrend::growth_delta` is now `Option<i64>`: migrate typed consumers to handle `None`
+  as unavailable direction. Report JSON renders that case as `null`; `Some(0)`/JSON `0` now
+  unambiguously means an observed flat multi-sample episode.
+
 ### 0.4 core API migration
 
 - Analyzer configuration now uses direct nested `AnalyzeOptions` mutation; the eight `with_*` closure wrappers and `valid_override_paths()` were removed. Derive paths from `analyze_option_descriptors()` and its read-only descriptor getters. Detailed CLI discovery moved from `analyze --help-analyzer-options` to `tailtriage analyzer-options`, and `analyze` now requires `RUN_JSON` at Clap parsing.

--- a/SPEC.md
+++ b/SPEC.md
@@ -211,8 +211,8 @@ Analyzer output includes:
 - `inflight_trend` summarizes the selected label's latest retained activity episode. Positive
   samples start or continue an episode; the first retained zero closes it, and later positive
   activity starts a new episode. Active episodes outrank closed historical episodes. Sample
-  count, peak, p95, and delta are episode-local. A one-sample episode has unknown direction
-  while retaining `growth_delta = 0` for compatibility. Precise rates use only valid
+  count, peak, p95, and delta are episode-local. `growth_delta` is `null` for a one-sample
+  episode with unavailable direction; numeric `0` means observed flatness. Precise rates use only valid
   run-relative microsecond timing; `null` means unavailable, and Unix milliseconds are only a
   coarse ordering fallback. Truncation never causes analysis to invent a missing closure.
   Growth supports a triage lead and is not root-cause proof.

--- a/tailtriage-analyzer/src/lib.rs
+++ b/tailtriage-analyzer/src/lib.rs
@@ -148,9 +148,9 @@ pub struct InflightTrend {
     pub peak_count: u64,
     /// p95 in-flight count for the episode.
     pub p95_count: u64,
-    /// Episode-local net growth (`last - first`). With fewer than two samples,
-    /// zero represents unknown direction rather than observed flatness.
-    pub growth_delta: i64,
+    /// Episode-local net growth (`last - first`), or `None` when fewer than two
+    /// samples make direction unavailable. `Some(0)` means observed flatness.
+    pub growth_delta: Option<i64>,
     /// Growth rate in milli-counts/sec when valid run-relative microsecond timing permits it.
     pub growth_per_sec_milli: Option<i64>,
 }
@@ -741,7 +741,7 @@ pub(crate) struct InflightCandidate {
 
 impl InflightCandidate {
     pub(crate) fn known_positive_growth(&self) -> bool {
-        self.trend.sample_count >= 2 && self.trend.growth_delta > 0
+        self.trend.growth_delta.is_some_and(|delta| delta > 0)
     }
 }
 
@@ -805,7 +805,7 @@ fn inflight_trend_for_gauge(
         .collect::<Vec<_>>();
     let first = latest.first()?.1;
     let last = latest.last()?.1;
-    let growth_delta = signed_u64_delta(first.count, last.count);
+    let growth_delta = (latest.len() >= 2).then(|| signed_u64_delta(first.count, last.count));
     let growth_per_sec_milli = (latest.len() >= 2 && ordering == InflightOrdering::RunRelative)
         .then(|| {
             let times = latest
@@ -816,7 +816,7 @@ fn inflight_trend_for_gauge(
             if elapsed == 0 || !times.windows(2).all(|pair| pair[0] <= pair[1]) {
                 return None;
             }
-            let rate = i128::from(growth_delta) * 1_000_000_000i128 / i128::from(elapsed);
+            let rate = i128::from(growth_delta?) * 1_000_000_000i128 / i128::from(elapsed);
             Some(
                 i64::try_from(rate.clamp(i128::from(i64::MIN), i128::from(i64::MAX)))
                     .expect("clamped growth rate fits i64"),

--- a/tailtriage-analyzer/src/render.rs
+++ b/tailtriage-analyzer/src/render.rs
@@ -128,10 +128,9 @@ pub fn render_text(report: &Report) -> String {
 }
 
 fn render_inflight_trend(trend: &crate::InflightTrend) -> String {
-    let direction = if trend.sample_count < 2 {
-        "direction unknown".to_string()
-    } else {
-        format!("net growth {:+}", trend.growth_delta)
+    let direction = match trend.growth_delta {
+        None => "direction unknown".to_string(),
+        Some(delta) => format!("net growth {delta:+}"),
     };
     let rate = trend.growth_per_sec_milli.map_or_else(
         || "precise rate unavailable".to_string(),

--- a/tailtriage-analyzer/src/scoring.rs
+++ b/tailtriage-analyzer/src/scoring.rs
@@ -430,18 +430,21 @@ pub(super) fn executor_pressure_suspect(
 
 fn inflight_growth_evidence(candidate: &InflightCandidate) -> String {
     let trend = &candidate.trend;
+    let growth_delta = trend
+        .growth_delta
+        .expect("in-flight growth evidence requires known positive growth");
     match (candidate.ordering, trend.growth_per_sec_milli) {
         (_, Some(rate)) => format!(
             "In-flight gauge '{}' latest active episode grew by {} across {} samples (p95={}, peak={}, run-relative rate={} milli-counts/sec).",
-            trend.gauge, trend.growth_delta, trend.sample_count, trend.p95_count, trend.peak_count, rate
+            trend.gauge, growth_delta, trend.sample_count, trend.p95_count, trend.peak_count, rate
         ),
         (InflightOrdering::UnixFallback, None) => format!(
             "In-flight gauge '{}' latest active episode grew by {} across {} samples (p95={}, peak={}); ordering used Unix-ms fallback and no precise growth rate was derived.",
-            trend.gauge, trend.growth_delta, trend.sample_count, trend.p95_count, trend.peak_count
+            trend.gauge, growth_delta, trend.sample_count, trend.p95_count, trend.peak_count
         ),
         (InflightOrdering::RunRelative, None) => format!(
             "In-flight gauge '{}' latest active episode grew by {} across {} samples (p95={}, peak={}); precise run-relative growth rate is unavailable.",
-            trend.gauge, trend.growth_delta, trend.sample_count, trend.p95_count, trend.peak_count
+            trend.gauge, growth_delta, trend.sample_count, trend.p95_count, trend.peak_count
         ),
     }
 }

--- a/tailtriage-analyzer/src/tests.rs
+++ b/tailtriage-analyzer/src/tests.rs
@@ -2188,7 +2188,7 @@ fn inflight_trend_handles_constant_series() {
 
     assert_eq!(trend.peak_count, 3);
     assert_eq!(trend.p95_count, 3);
-    assert_eq!(trend.growth_delta, 0);
+    assert_eq!(trend.growth_delta, Some(0));
 }
 
 // TT-TEST: support
@@ -2218,7 +2218,7 @@ fn inflight_trend_handles_monotonic_increase() {
 
     assert_eq!(trend.peak_count, 6);
     assert_eq!(trend.p95_count, 6);
-    assert_eq!(trend.growth_delta, 5);
+    assert_eq!(trend.growth_delta, Some(5));
     assert_eq!(trend.growth_per_sec_milli, None);
 }
 
@@ -2255,7 +2255,7 @@ fn latest_active_inflight_episode_outranks_closed_historical_spike() {
             sample_count: 3,
             peak_count: 4,
             p95_count: 4,
-            growth_delta: 3,
+            growth_delta: Some(3),
             growth_per_sec_milli: Some(1500)
         }
     );
@@ -2279,7 +2279,7 @@ fn reused_inflight_label_uses_only_latest_episode() {
             trend.growth_delta,
             trend.growth_per_sec_milli
         ),
-        (3, 5, 5, 3, Some(1500))
+        (3, 5, 5, Some(3), Some(1500))
     );
 }
 
@@ -2294,7 +2294,7 @@ fn leading_and_consecutive_zero_snapshots_do_not_create_episodes() {
     let trend = super::dominant_inflight_trend(&samples).unwrap();
     assert_eq!(
         (trend.sample_count, trend.peak_count, trend.growth_delta),
-        (2, 3, -3)
+        (2, 3, Some(-3))
     );
 }
 
@@ -2319,7 +2319,7 @@ fn run_relative_time_orders_inflight_samples_before_wall_clock() {
     .unwrap();
     assert_eq!(
         (trend.growth_delta, trend.growth_per_sec_milli),
-        (5, Some(2_500_000_000))
+        (Some(5), Some(2_500_000_000))
     );
 }
 
@@ -2331,7 +2331,10 @@ fn inflight_wall_clock_fallback_is_deterministic_without_rate() {
         inflight("g", 10, None, 2),
     ])
     .unwrap();
-    assert_eq!((trend.growth_delta, trend.growth_per_sec_milli), (3, None));
+    assert_eq!(
+        (trend.growth_delta, trend.growth_per_sec_milli),
+        (Some(3), None)
+    );
 }
 
 // TT-TEST: support
@@ -2362,7 +2365,10 @@ fn equal_timestamp_inflight_order_uses_original_input_index() {
         inflight("g", 1, Some(1), 2),
     ])
     .unwrap();
-    assert_eq!((forward.growth_delta, reverse.growth_delta), (3, -3));
+    assert_eq!(
+        (forward.growth_delta, reverse.growth_delta),
+        (Some(3), Some(-3))
+    );
     assert_eq!(forward.growth_per_sec_milli, None);
 }
 
@@ -2377,7 +2383,7 @@ fn one_sample_inflight_episode_is_unknown_and_adds_no_bonus() {
             sample_count: 1,
             peak_count: 7,
             p95_count: 7,
-            growth_delta: 0,
+            growth_delta: None,
             growth_per_sec_milli: None
         }
     );
@@ -2406,7 +2412,7 @@ fn inflight_candidate_order_prefers_active_over_closed() {
             sample_count: 2,
             peak_count: 5,
             p95_count: 5,
-            growth_delta: 0,
+            growth_delta: Some(0),
             growth_per_sec_milli: Some(0),
         },
     );
@@ -2427,7 +2433,7 @@ fn inflight_candidate_order_prefers_positive_over_unknown() {
             sample_count: 2,
             peak_count: 2,
             p95_count: 2,
-            growth_delta: 1,
+            growth_delta: Some(1),
             growth_per_sec_milli: Some(1000),
         },
     );
@@ -2450,7 +2456,7 @@ fn inflight_candidate_order_prefers_positive_over_non_growing() {
                 sample_count: 2,
                 peak_count: 2,
                 p95_count: 2,
-                growth_delta: 1,
+                growth_delta: Some(1),
                 growth_per_sec_milli: Some(1000),
             },
         );
@@ -2473,7 +2479,7 @@ fn inflight_candidate_order_prefers_larger_positive_delta() {
             sample_count: 2,
             peak_count: 6,
             p95_count: 6,
-            growth_delta: 5,
+            growth_delta: Some(5),
             growth_per_sec_milli: Some(5000),
         },
     );
@@ -2494,7 +2500,7 @@ fn inflight_candidate_order_prefers_available_positive_rate() {
             sample_count: 2,
             peak_count: 4,
             p95_count: 4,
-            growth_delta: 3,
+            growth_delta: Some(3),
             growth_per_sec_milli: Some(1500),
         },
     );
@@ -2516,7 +2522,7 @@ fn inflight_candidate_order_prefers_larger_positive_rate() {
             sample_count: 2,
             peak_count: 4,
             p95_count: 4,
-            growth_delta: 3,
+            growth_delta: Some(3),
             growth_per_sec_milli: Some(3000),
         },
     );
@@ -2539,7 +2545,7 @@ fn inflight_candidate_order_prefers_larger_p95() {
             sample_count: 21,
             peak_count: 8,
             p95_count: 8,
-            growth_delta: 0,
+            growth_delta: Some(0),
             growth_per_sec_milli: Some(0),
         },
     );
@@ -2558,7 +2564,7 @@ fn inflight_candidate_order_prefers_larger_peak() {
             sample_count: 21,
             peak_count: 10,
             p95_count: 1,
-            growth_delta: -9,
+            growth_delta: Some(-9),
             growth_per_sec_milli: Some(-450_000_000),
         },
     );
@@ -2579,7 +2585,7 @@ fn inflight_candidate_order_uses_lexical_label_last() {
             sample_count: 2,
             peak_count: 2,
             p95_count: 2,
-            growth_delta: 0,
+            growth_delta: Some(0),
             growth_per_sec_milli: Some(0),
         },
     );
@@ -2598,18 +2604,18 @@ fn truncated_inflight_history_does_not_infer_missing_zero() {
         .expect("analyzer options should be valid")
         .inflight_trend
         .unwrap();
-    assert_eq!((trend.sample_count, trend.growth_delta), (2, 1));
+    assert_eq!((trend.sample_count, trend.growth_delta), (2, Some(1)));
 }
 
 // TT-TEST: support
 #[test]
-fn inflight_trend_json_shape_and_values_remain_unchanged() {
+fn inflight_trend_json_distinguishes_unavailable_from_flat() {
     let value = serde_json::to_value(InflightTrend {
         gauge: "g".into(),
         sample_count: 3,
         peak_count: 4,
         p95_count: 4,
-        growth_delta: 3,
+        growth_delta: Some(3),
         growth_per_sec_milli: Some(1500),
     })
     .unwrap();
@@ -2630,7 +2636,7 @@ fn inflight_trend_json_shape_and_values_remain_unchanged() {
             sample_count: 1,
             peak_count: 4,
             p95_count: 4,
-            growth_delta: 0,
+            growth_delta: None,
             growth_per_sec_milli: None,
         })
         .unwrap(),
@@ -2639,9 +2645,21 @@ fn inflight_trend_json_shape_and_values_remain_unchanged() {
             "sample_count": 1,
             "peak_count": 4,
             "p95_count": 4,
-            "growth_delta": 0,
+            "growth_delta": null,
             "growth_per_sec_milli": null
         })
+    );
+    assert_eq!(
+        serde_json::to_value(InflightTrend {
+            gauge: "flat".into(),
+            sample_count: 2,
+            peak_count: 4,
+            p95_count: 4,
+            growth_delta: Some(0),
+            growth_per_sec_milli: None,
+        })
+        .unwrap()["growth_delta"],
+        serde_json::json!(0)
     );
 }
 
@@ -2703,7 +2721,7 @@ fn closed_historical_inflight_spike_adds_no_bonus_when_active_flat_episode_wins(
             sample_count: 2,
             peak_count: 5,
             p95_count: 5,
-            growth_delta: 0,
+            growth_delta: Some(0),
             growth_per_sec_milli: Some(0),
         })
     );
@@ -2848,15 +2866,30 @@ fn declining_inflight_episode_adds_no_growth_bonus() {
 
 // TT-TEST: support
 #[test]
-fn render_text_marks_one_sample_inflight_trend_unknown() {
-    let report = analyze_run(
+fn render_text_uses_growth_delta_as_direction_source_of_truth() {
+    let mut report = analyze_run(
         &queue_bonus_run(vec![inflight("single", 1, Some(1), 7)]),
         AnalyzeOptions::default(),
     )
     .expect("analyzer options should be valid");
+    report.inflight_trend.as_mut().unwrap().sample_count = 2;
     let text = render_text(&report);
     assert!(text.contains("direction unknown") && text.contains("precise rate unavailable"));
     assert!(!text.contains("net growth +0"));
+    let json: serde_json::Value = serde_json::from_str(&render_json(&report).unwrap()).unwrap();
+    assert_eq!(
+        json["inflight_trend"]["growth_delta"],
+        serde_json::Value::Null
+    );
+
+    let trend = report.inflight_trend.as_mut().unwrap();
+    trend.sample_count = 1;
+    trend.growth_delta = Some(0);
+    let text = render_text(&report);
+    assert!(text.contains("net growth +0"));
+    assert!(!text.contains("direction unknown"));
+    let json: serde_json::Value = serde_json::from_str(&render_json(&report).unwrap()).unwrap();
+    assert_eq!(json["inflight_trend"]["growth_delta"], 0);
 }
 
 // TT-TEST: S04 primary
@@ -2899,7 +2932,7 @@ fn render_text_formats_inflight_trend_fields() {
             sample_count: 4,
             peak_count: 8,
             p95_count: 7,
-            growth_delta: 5,
+            growth_delta: Some(5),
             growth_per_sec_milli: Some(2_500),
         }),
         warnings: Vec::new(),

--- a/tailtriage-tracing/tests/equivalence_contract.rs
+++ b/tailtriage-tracing/tests/equivalence_contract.rs
@@ -566,7 +566,7 @@ fn equivalence_projections_detect_every_contract_field_mutation() {
                 sample_count: 7,
                 peak_count: 8,
                 p95_count: 9,
-                growth_delta: 10,
+                growth_delta: Some(10),
                 growth_per_sec_milli: Some(11)
             }),
         |x: &mut ComparableReportProjection| x.inflight_trend = serde_json::json!({"gauge":"mutated-gauge","sample_count":7,"peak_count":8,"p95_count":9,"growth_delta":10,"growth_per_sec_milli":11})


### PR DESCRIPTION
### Motivation

- Fix an information-model defect so an unavailable in-flight trend direction is distinct from an observed flat multi-sample episode.
- Preserve all analyzer semantics and deterministic candidate/ranking behavior while making the direction-availability the single source of truth.

### Description

- Change `InflightTrend::growth_delta` from `i64` to `Option<i64>` so `None` = direction unavailable and `Some(0)` = observed flatness, leaving `growth_per_sec_milli` semantics unchanged.
- Update the producer logic to set `growth_delta = None` for one-sample retained episodes and to compute a signed delta for two-or-more samples; keep rate computation dependent on valid timing and a known delta.
- Update consumers: positive-growth eligibility, candidate comparison/tie rules, scoring evidence rendering, and text/JSON renderers to derive direction availability from the new `Option` type without changing ranking logic or numeric comparisons when both sides have known deltas.
- Update unit tests, serialization tests, and the tracing equivalence projection to cover all four classes (None, Some(0), positive, negative), and update `SPEC.md` and `CHANGELOG.md` to document the change in JSON rendering (`null` vs numeric `0`).

### Testing

- Ran focused and workspace validations: `cargo test -p tailtriage-analyzer --all-targets --all-features --locked`, `cargo test -p tailtriage-cli --all-targets --all-features --locked`, and full workspace runs of `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `cargo test --workspace --all-targets --all-features --locked`, `python3 scripts/validate_docs_contracts.py`, `python3 scripts/validate_invariant_proofs.py`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`.
- All automated checks and tests passed successfully (no failures reported).
- Inspected invariant proof markers (including A02, A05, A12, L05, F01, F05, and S04); no primary invariant semantic was weakened and any test edits were syntax-only where the invariant remained unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9882ce834c83309245f9ecaf79f55c)