### PR TITLE
api: simplify tokio request helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 ### 0.4 core API migration
 
+- Tokio semaphore helpers are now awaited directly: replace
+  `.semaphore(...).acquire().await` with `.semaphore(...).await` and
+  `.owned_semaphore(...).acquire_owned().await` with `.owned_semaphore(...).await`.
+  The intermediate `InstrumentedSemaphore` and `InstrumentedOwnedSemaphore` types were removed.
+  Replace the redundant Tokio `inflight_guard(...)` alias with the canonical core
+  `inflight(...)` method.
+
 - Diagnosis taxonomy and Report vocabulary changed as follows:
 
   | Previous Rust variant / machine label | 0.4 Rust variant / machine label |

--- a/demos/collector_stress/src/main.rs
+++ b/demos/collector_stress/src/main.rs
@@ -512,9 +512,9 @@ async fn run_instrumented_request(
 
     for cycle in 0..inflight_cycles {
         let gauge = format!("collector_stress_inflight_{cycle}");
-        let inflight_guard = request.inflight(gauge);
+        let inflight = request.inflight(gauge);
         tokio::task::yield_now().await;
-        drop(inflight_guard);
+        drop(inflight);
     }
 
     for queue_idx in 0..queues_per_request {

--- a/demos/executor_pressure_service/src/main.rs
+++ b/demos/executor_pressure_service/src/main.rs
@@ -193,7 +193,7 @@ async fn run_request_cohort(
                         request_id,
                         tailtriage_core::Outcome::Ok,
                         |request| async move {
-                            let inflight_guard = request.inflight("executor_pressure_inflight");
+                            let inflight = request.inflight("executor_pressure_inflight");
                             execute_request_work(
                                 fanout_tasks,
                                 cpu_turns,
@@ -201,7 +201,7 @@ async fn run_request_cohort(
                                 Arc::clone(&hot_slice_local_depth),
                             )
                             .await;
-                            drop(inflight_guard);
+                            drop(inflight);
                         },
                     )
                     .await;

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -414,15 +414,15 @@ These helpers are shorthand for explicit `queue(...).await_on(...)`, `stage(...)
 
 | Use case | Helper | Records |
 |---|---|---|
-| DB pool / capacity wait | `semaphore(...).acquire()` | queue |
-| owned permit wait | `owned_semaphore(...).acquire_owned()` | queue |
+| DB pool / capacity wait | `semaphore(...).await` | queue |
+| owned permit wait | `owned_semaphore(...).await` | queue |
 | bounded channel backpressure | `mpsc_send(...)` | queue |
 | async mutex contention | `mutex_lock(...)` | queue |
 | async rwlock contention | `rwlock_read(...)` / `rwlock_write(...)` | queue |
 | spawned task result | `join_task(...)` | stage |
 | timeout-wrapped work | `timeout_stage(...)` | stage |
 | blocking pool work | `blocking_stage(...)` | stage |
-| active bounded section | `inflight_guard(...)` | in-flight |
+| active bounded section | `inflight(...)` | in-flight |
 
 Semantics notes:
 

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -100,6 +100,32 @@ class ValidateDocsContractsTests(unittest.TestCase):
         self._assert_residual_api_rejected('tailtriage-core/src/run_builder.rs', 'pub fn finish(self) -> Run { todo!() }', 'RunBuilder::finish')
 
     # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_rejects_removed_tokio_request_helpers(self) -> None:
+        for symbol, source in (
+            ('TokioRequestHandleExt::inflight_guard', 'pub trait TokioRequestHandleExt { fn inflight_guard(&self); }'),
+            ('public InstrumentedSemaphore', 'pub struct InstrumentedSemaphore;'),
+            ('public InstrumentedOwnedSemaphore', 'pub struct InstrumentedOwnedSemaphore;'),
+        ):
+            with self.subTest(symbol=symbol):
+                self._assert_residual_api_rejected('tailtriage-tokio/src/lib.rs', source, symbol)
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_accepts_direct_tokio_semaphore_futures(self) -> None:
+        source = '''pub trait TokioRequestHandleExt {
+    fn semaphore<'req, 'sem>(&'req self, semaphore: &'sem Semaphore)
+        -> impl Future<Output = Result<SemaphorePermit<'sem>, AcquireError>> + 'req
+        where 'sem: 'req;
+    fn owned_semaphore(&self, semaphore: Arc<Semaphore>)
+        -> impl Future<Output = Result<OwnedSemaphorePermit, AcquireError>> + '_;
+}
+'''
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            self._write_residual_api_sources(root, {'tailtriage-tokio/src/lib.rs': source})
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
+                validate_docs_contracts.validate_residual_public_api_cleanup()
+
+    # TT-TEST: M02 secondary
     def test_residual_public_api_cleanup_rejects_removed_analyzer_methods(self) -> None:
         for method in ('with_queueing', 'with_blocking', 'with_executor', 'with_downstream',
                        'with_confidence', 'with_evidence', 'with_route', 'with_temporal'):

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -498,6 +498,20 @@ def validate_residual_public_api_cleanup() -> None:
         REPO_ROOT / "tailtriage-core" / "src" / "run_builder.rs": (
             ("RunBuilder::finish", r"\bpub\s+fn\s+finish\s*\([^)]*\)\s*->\s*Run\b"),
         ),
+        REPO_ROOT / "tailtriage-tokio" / "src" / "lib.rs": (
+            (
+                "TokioRequestHandleExt::inflight_guard",
+                r"\bfn\s+inflight_guard\s*\(",
+            ),
+            (
+                "public InstrumentedSemaphore",
+                r"\bpub\s+struct\s+InstrumentedSemaphore\b",
+            ),
+            (
+                "public InstrumentedOwnedSemaphore",
+                r"\bpub\s+struct\s+InstrumentedOwnedSemaphore\b",
+            ),
+        ),
         REPO_ROOT / "tailtriage-core" / "src" / "lib.rs": (
             (
                 "RuntimeSamplerRegistrationError",

--- a/tailtriage-tokio/README.md
+++ b/tailtriage-tokio/README.md
@@ -127,7 +127,7 @@ async fn demo() -> Result<(), Box<dyn std::error::Error>> {
 
     let db_pool = Arc::new(tokio::sync::Semaphore::new(32));
     {
-        let _permit = req.semaphore("db_pool_wait", &db_pool).acquire().await?;
+        let _permit = req.semaphore("db_pool_wait", &db_pool).await?;
 
         let _: Result<Result<(), ()>, tokio::time::error::Elapsed> = req
             .timeout_stage("downstream_http", Duration::from_millis(200), async {
@@ -281,15 +281,15 @@ Helpers map common Tokio primitives to explicit queue/stage/in-flight signals wh
 
 | Use case                     | Helper                                   | Records   |
 | ---------------------------- | ---------------------------------------- | --------- |
-| DB pool / capacity wait      | `semaphore(...).acquire()`               | queue     |
-| owned permit wait            | `owned_semaphore(...).acquire_owned()`   | queue     |
+| DB pool / capacity wait      | `semaphore(...).await`                   | queue     |
+| owned permit wait            | `owned_semaphore(...).await`             | queue     |
 | bounded channel backpressure | `mpsc_send(...)`                         | queue     |
 | async mutex contention       | `mutex_lock(...)`                        | queue     |
 | async rwlock contention      | `rwlock_read(...)` / `rwlock_write(...)` | queue     |
 | spawned task result          | `join_task(...)`                         | stage     |
 | timeout-wrapped work         | `timeout_stage(...)`                     | stage     |
 | blocking pool work           | `blocking_stage(...)`                    | stage     |
-| active bounded section       | `inflight_guard(...)`                    | in-flight |
+| active bounded section       | `inflight(...)`                           | in-flight |
 
 ### Semantics notes
 
@@ -317,7 +317,11 @@ let req = started.handle.clone();
 
 let db_pool = Arc::new(tokio::sync::Semaphore::new(32));
 {
-    let _permit = req.semaphore("db_pool_wait", &db_pool).acquire().await?;
+    let _permit = req.semaphore("db_pool_wait", &db_pool).await?;
+    let _owned = req
+        .owned_semaphore("owned_db_pool_wait", Arc::clone(&db_pool))
+        .await?;
+    let _guard = req.inflight("database");
     let _: Result<Result<(), ()>, tokio::time::error::Elapsed> = req
         .timeout_stage("downstream_http", Duration::from_millis(200), async {
             Ok::<(), ()>(())

--- a/tailtriage-tokio/src/lib.rs
+++ b/tailtriage-tokio/src/lib.rs
@@ -30,7 +30,7 @@ mod sealed {
 pub trait TokioRequestHandleExt: sealed::Sealed {
     /// Records a queue event while waiting to acquire a semaphore permit.
     ///
-    /// Equivalent low-level form: `req.queue(label).await_on(semaphore.acquire())` via [`InstrumentedSemaphore::acquire`].
+    /// Equivalent low-level form: `req.queue(label).await_on(semaphore.acquire())`.
     ///
     /// Records only acquisition wait time, not the protected work after the permit is acquired.
     /// Timing starts on first poll; dropping before first poll records no event, and dropping after a pending poll records one bounded partial queue event if capture remains open.
@@ -39,10 +39,12 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
         &'req self,
         queue: impl Into<String>,
         semaphore: &'sem tokio::sync::Semaphore,
-    ) -> InstrumentedSemaphore<'req, 'sem>;
+    ) -> impl Future<Output = Result<tokio::sync::SemaphorePermit<'sem>, tokio::sync::AcquireError>> + 'req
+    where
+        'sem: 'req;
     /// Records a queue event while waiting to acquire an owned semaphore permit.
     ///
-    /// Equivalent low-level form: `req.queue(label).await_on(semaphore.acquire_owned())` via [`InstrumentedOwnedSemaphore::acquire_owned`].
+    /// Equivalent low-level form: `req.queue(label).await_on(semaphore.acquire_owned())`.
     ///
     /// Records only acquisition wait time, not work after permit acquisition.
     /// Timing starts on first poll; dropping before first poll records no event, and dropping after a pending poll records one bounded partial queue event if capture remains open.
@@ -51,7 +53,7 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
         &self,
         queue: impl Into<String>,
         semaphore: Arc<tokio::sync::Semaphore>,
-    ) -> InstrumentedOwnedSemaphore<'_>;
+    ) -> impl Future<Output = Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError>> + '_;
     /// Records a queue event while waiting for bounded-channel send/backpressure.
     ///
     /// Equivalent low-level form: `req.queue(label).await_on(sender.send(value))`.
@@ -159,12 +161,6 @@ pub trait TokioRequestHandleExt: sealed::Sealed {
     where
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static;
-    /// Alias for `inflight(...)` for RAII discoverability.
-    ///
-    /// Equivalent low-level form: `req.inflight(label)`.
-    ///
-    /// Records in-flight gauge increments/decrements only. It does not record queue or stage timing. Request completion remains explicit.
-    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_>;
 }
 
 impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
@@ -172,21 +168,19 @@ impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
         &'req self,
         queue: impl Into<String>,
         semaphore: &'sem tokio::sync::Semaphore,
-    ) -> InstrumentedSemaphore<'req, 'sem> {
-        InstrumentedSemaphore {
-            timer: self.queue(queue),
-            semaphore,
-        }
+    ) -> impl Future<Output = Result<tokio::sync::SemaphorePermit<'sem>, tokio::sync::AcquireError>> + 'req
+    where
+        'sem: 'req,
+    {
+        self.queue(queue).await_on(semaphore.acquire())
     }
     fn owned_semaphore(
         &self,
         queue: impl Into<String>,
         semaphore: Arc<tokio::sync::Semaphore>,
-    ) -> InstrumentedOwnedSemaphore<'_> {
-        InstrumentedOwnedSemaphore {
-            timer: self.queue(queue),
-            semaphore,
-        }
+    ) -> impl Future<Output = Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError>> + '_
+    {
+        self.queue(queue).await_on(semaphore.acquire_owned())
     }
     fn mpsc_send<'a, T>(
         &'a self,
@@ -261,9 +255,6 @@ impl TokioRequestHandleExt for tailtriage_core::RequestHandle<'_> {
                 .await_on(async move { tokio::task::spawn_blocking(f).await })
                 .await
         }
-    }
-    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
-        self.inflight(gauge)
     }
 }
 
@@ -272,21 +263,19 @@ impl TokioRequestHandleExt for tailtriage_core::OwnedRequestHandle {
         &'req self,
         queue: impl Into<String>,
         semaphore: &'sem tokio::sync::Semaphore,
-    ) -> InstrumentedSemaphore<'req, 'sem> {
-        InstrumentedSemaphore {
-            timer: self.queue(queue),
-            semaphore,
-        }
+    ) -> impl Future<Output = Result<tokio::sync::SemaphorePermit<'sem>, tokio::sync::AcquireError>> + 'req
+    where
+        'sem: 'req,
+    {
+        self.queue(queue).await_on(semaphore.acquire())
     }
     fn owned_semaphore(
         &self,
         queue: impl Into<String>,
         semaphore: Arc<tokio::sync::Semaphore>,
-    ) -> InstrumentedOwnedSemaphore<'_> {
-        InstrumentedOwnedSemaphore {
-            timer: self.queue(queue),
-            semaphore,
-        }
+    ) -> impl Future<Output = Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError>> + '_
+    {
+        self.queue(queue).await_on(semaphore.acquire_owned())
     }
     fn mpsc_send<'a, T>(
         &'a self,
@@ -361,46 +350,6 @@ impl TokioRequestHandleExt for tailtriage_core::OwnedRequestHandle {
                 .await_on(async move { tokio::task::spawn_blocking(f).await })
                 .await
         }
-    }
-    fn inflight_guard(&self, gauge: impl Into<String>) -> tailtriage_core::InflightGuard<'_> {
-        self.inflight(gauge)
-    }
-}
-
-/// Queue-instrumented semaphore acquisition helper.
-#[must_use = "constructing the wrapper records nothing until acquire() is awaited"]
-pub struct InstrumentedSemaphore<'req, 'sem> {
-    timer: tailtriage_core::QueueTimer<'req>,
-    semaphore: &'sem tokio::sync::Semaphore,
-}
-impl<'sem> InstrumentedSemaphore<'_, 'sem> {
-    /// Awaits a borrowed semaphore permit while recording queue wait duration.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tokio::sync::AcquireError`] when the semaphore is closed.
-    pub async fn acquire(
-        self,
-    ) -> Result<tokio::sync::SemaphorePermit<'sem>, tokio::sync::AcquireError> {
-        self.timer.await_on(self.semaphore.acquire()).await
-    }
-}
-/// Queue-instrumented owned semaphore acquisition helper.
-#[must_use = "constructing the wrapper records nothing until acquire_owned() is awaited"]
-pub struct InstrumentedOwnedSemaphore<'a> {
-    timer: tailtriage_core::QueueTimer<'a>,
-    semaphore: Arc<tokio::sync::Semaphore>,
-}
-impl InstrumentedOwnedSemaphore<'_> {
-    /// Awaits an owned semaphore permit while recording queue wait duration.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`tokio::sync::AcquireError`] when the semaphore is closed.
-    pub async fn acquire_owned(
-        self,
-    ) -> Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError> {
-        self.timer.await_on(self.semaphore.acquire_owned()).await
     }
 }
 
@@ -1178,7 +1127,6 @@ mod helper_tests {
         semaphore: &'s tokio::sync::Semaphore,
     ) -> tokio::sync::SemaphorePermit<'s> {
         req.semaphore("sem_lifetime", semaphore)
-            .acquire()
             .await
             .expect("permit")
     }
@@ -1211,18 +1159,19 @@ mod helper_tests {
         let started = run.begin_request("/helpers");
         let req = started.handle.clone();
         let sem = Arc::new(tokio::sync::Semaphore::new(1));
-        let permit = req.semaphore("sem", &sem).acquire().await.expect("permit");
+        let permit = req.semaphore("sem", &sem).await.expect("permit");
         drop(permit);
-        let owned = req
+        let owned: tokio::sync::OwnedSemaphorePermit = req
             .owned_semaphore("owned_sem", Arc::clone(&sem))
-            .acquire_owned()
             .await
             .expect("owned permit");
         drop(owned);
 
         let closed = tokio::sync::Semaphore::new(0);
         closed.close();
-        assert!(req.semaphore("closed", &closed).acquire().await.is_err());
+        let closed_result: Result<tokio::sync::SemaphorePermit<'_>, tokio::sync::AcquireError> =
+            req.semaphore("closed", &closed).await;
+        assert!(closed_result.is_err());
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(1);
         tx.send(7u8).await.expect("seed send");
@@ -1321,7 +1270,7 @@ mod helper_tests {
             .is_err());
 
         {
-            let _g = req.inflight_guard("busy");
+            let _g = req.inflight("busy");
             assert_eq!(run.snapshot().inflight.len(), 1);
         }
         let inflight_snap = run.snapshot();
@@ -1503,10 +1452,18 @@ mod helper_tests {
         let sem = Arc::new(tokio::sync::Semaphore::new(1));
         let permit = owned
             .owned_semaphore("owned_sem", Arc::clone(&sem))
-            .acquire_owned()
             .await
             .expect("owned permit");
         drop(permit);
+        let borrowed_permit: tokio::sync::SemaphorePermit<'_> = owned
+            .semaphore("owned_handle_borrowed_sem", &sem)
+            .await
+            .expect("borrowed permit from owned request handle");
+        drop(borrowed_permit);
+        {
+            let _inflight = owned.inflight("owned_busy");
+            assert!(run.snapshot().requests.is_empty());
+        }
         let _ = owned
             .timeout_stage("owned_timeout", Duration::from_millis(10), async { 1usize })
             .await
@@ -1606,23 +1563,44 @@ mod prompt09_tokio_partial_tests {
 
     // TT-TEST: T01 primary
     #[tokio::test(flavor = "current_thread")]
+    async fn unpolled_semaphore_futures_record_nothing() {
+        let tt = capture();
+        let started = tt.begin_request("/r");
+        let borrowed = tokio::sync::Semaphore::new(1);
+        drop(started.handle.semaphore("borrowed_unpolled", &borrowed));
+
+        let owned = Arc::new(tokio::sync::Semaphore::new(1));
+        drop(
+            started
+                .handle
+                .owned_semaphore("owned_unpolled", Arc::clone(&owned)),
+        );
+
+        assert!(tt.snapshot().queues.is_empty());
+        started.completion.finish_ok();
+    }
+
+    // TT-TEST: T01 primary
+    #[tokio::test(flavor = "current_thread")]
     async fn borrowed_semaphore_pending_then_drop_records_partial_queue() {
         let tt = capture();
         let started = tt.begin_request_with("/r", RequestOptions::new().request_id("req"));
         let sem = tokio::sync::Semaphore::new(1);
         let permit = sem.acquire().await.unwrap();
-        let fut = started.handle.semaphore("sem", &sem).acquire();
+        let fut = started.handle.semaphore("sem", &sem);
         let mut fut = Box::pin(fut);
         assert!(poll_once(&mut fut).is_pending());
         drop(fut);
         drop(permit);
-        let ev = &tt.snapshot().queues[0];
+        let snapshot = tt.snapshot();
+        assert_eq!(snapshot.queues.len(), 1);
+        let ev = &snapshot.queues[0];
         assert_eq!(ev.request_id, "req");
         assert_eq!(ev.queue, "sem");
         assert!(!ev.completed);
     }
 
-    // TT-TEST: K02 secondary
+    // TT-TEST: T01 primary
     #[tokio::test(flavor = "current_thread")]
     async fn owned_semaphore_pending_then_drop_records_partial_queue() {
         let tt = capture();
@@ -1631,13 +1609,14 @@ mod prompt09_tokio_partial_tests {
         let permit = sem.acquire().await.unwrap();
         let fut = started
             .handle
-            .owned_semaphore("owned_sem", Arc::clone(&sem))
-            .acquire_owned();
+            .owned_semaphore("owned_sem", Arc::clone(&sem));
         let mut fut = Box::pin(fut);
         assert!(poll_once(&mut fut).is_pending());
         drop(fut);
         drop(permit);
-        let ev = &tt.snapshot().queues[0];
+        let snapshot = tt.snapshot();
+        assert_eq!(snapshot.queues.len(), 1);
+        let ev = &snapshot.queues[0];
         assert_eq!(ev.queue, "owned_sem");
         assert!(!ev.completed);
     }


### PR DESCRIPTION
### Motivation

- Remove a redundant alias and small public wrapper types to simplify the Tokio request-helper surface without changing runtime, timing, or lifetime semantics.
- Make semaphore helpers directly awaitable to reduce ceremony at call sites while preserving Tokio permit/error types and first-poll laziness.

### Description

- Changed `TokioRequestHandleExt::semaphore` to return `-> impl Future<Output = Result<tokio::sync::SemaphorePermit<'sem>, tokio::sync::AcquireError>> + 'req` with the lifetime bound `where 'sem: 'req`, and made `TokioRequestHandleExt::owned_semaphore` return `-> impl Future<Output = Result<tokio::sync::OwnedSemaphorePermit, tokio::sync::AcquireError>> + '_'` (both implemented via `self.queue(...).await_on(...)`).
- Removed the public wrapper types `InstrumentedSemaphore` and `InstrumentedOwnedSemaphore` and their `acquire()`/`acquire_owned()` methods, and removed the redundant `TokioRequestHandleExt::inflight_guard` alias in favor of the canonical `request.inflight(...)`.
- Updated implementations, tests, examples, README/rustdoc text, and `CHANGELOG.md` to teach and demonstrate the new direct-await usage (`.semaphore(...).await`, `.owned_semaphore(...).await`, and `.inflight(...)`).
- Extended `scripts/validate_docs_contracts.py` and its tests to reject reintroduction of `inflight_guard`, `InstrumentedSemaphore`, and `InstrumentedOwnedSemaphore` on the `tailtriage-tokio` public surface while accepting the new `impl Future` signatures (M02 proof fixtures).

### Testing

- Ran `cargo test -p tailtriage-tokio --all-targets --all-features --locked` and observed all tests pass for the crate (32 tests passed).
- Ran `cargo test -p tailtriage --all-targets --all-features --locked`, repository workspace `cargo test --workspace --all-targets --all-features --locked`, `python3 -m unittest scripts.tests.test_validate_docs_contracts`, and `python3 scripts/smoke_public_examples.py`, and all succeeded.
- Ran repository completion checks `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `python3 scripts/validate_docs_contracts.py`, `python3 scripts/validate_invariant_proofs.py`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`; all passed with a clean worktree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a997b59e2cc8330bc55de6149d9d276)