### PR TITLE
api: clarify tracing input and output ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
   as unavailable direction. Report JSON renders that case as `null`; `Some(0)`/JSON `0` now
   unambiguously means an observed flat multi-sample episode.
 
+### 0.4 tracing API migration
+
+- `SpanRecord` fluent construction now uses `with_id`, `with_parent_id`, `with_field`, `with_started_at_run_us`, `with_finished_at_run_us`, and `with_duration_us`. Its getters now use the exact model names `id`, `parent_id`, `started_at_run_us`, `finished_at_run_us`, and `duration_us` instead of the former `_ref` spellings.
+- `ImportOptions` inspection now uses `configured_service_version`, `configured_run_id`, `is_strict`, and `capture_mode` instead of `service_version_ref`, `run_id_ref`, `strict_mode`, and `mode_value`. Setters are unchanged.
+- `ImportedRun::new` and `ImportWarning::new` are now crate-owned constructors. Custom sources should construct `SpanRecord` inputs and obtain result values from `run_from_span_records(...)`.
+
 ### 0.4 core API migration
 
 - Tokio semaphore helpers are now awaited directly: replace

--- a/demos/demo_support/src/lib.rs
+++ b/demos/demo_support/src/lib.rs
@@ -628,8 +628,10 @@ pub async fn run_warmup_then_measured<Warmup, WarmupFut, Measured, MeasuredFut>(
 mod tests {
     use super::{parse_demo_args_from, write_persistable_demo_run, DemoMode, InstrumentationMode};
     use std::time::{SystemTime, UNIX_EPOCH};
-    use tailtriage_core::{Outcome, RequestEvent, Run, RunBuilder, RunBuilderOptions};
-    use tailtriage_tracing::ImportedRun;
+    use tailtriage_core::{Outcome, Run};
+    use tailtriage_tracing::{
+        run_from_span_records, ImportOptions, SpanRecord, TT_KIND, TT_REQUEST_ID, TT_ROUTE,
+    };
 
     // TT-TEST: support
     #[test]
@@ -709,7 +711,8 @@ mod tests {
     #[test]
     fn tracing_shutdown_writer_rejects_zero_requests_without_writing() {
         let output = unique_temp_output_path("empty-run");
-        let imported = ImportedRun::new(sample_run_without_requests(), Vec::new());
+        let imported = run_from_span_records([], ImportOptions::new("demo-service"))
+            .expect("produce empty imported run");
 
         let err = write_persistable_demo_run(&imported, &output).expect_err("expected rejection");
         assert!(err.to_string().contains("zero request events"));
@@ -720,38 +723,18 @@ mod tests {
     #[test]
     fn tracing_shutdown_writer_persists_non_empty_run_json() {
         let output = unique_temp_output_path("non-empty-run");
-        let run = sample_run_with_one_request();
-        let imported = ImportedRun::new(run, Vec::new());
+        let record = SpanRecord::new("request", 1, 2)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "req-1")
+            .with_field(TT_ROUTE, "route-a");
+        let imported = run_from_span_records([record], ImportOptions::new("demo-service"))
+            .expect("produce imported run");
 
         write_persistable_demo_run(&imported, &output).expect("write artifact");
         let raw = std::fs::read_to_string(&output).expect("read output");
         let parsed: Run = serde_json::from_str(&raw).expect("parse run json");
         assert_eq!(parsed.requests.len(), 1);
         let _ = std::fs::remove_file(&output);
-    }
-
-    fn sample_run_without_requests() -> Run {
-        RunBuilder::new(RunBuilderOptions::new("demo-service"))
-            .expect("build run")
-            .build()
-    }
-
-    fn sample_run_with_one_request() -> Run {
-        let mut builder = RunBuilder::new(RunBuilderOptions::new("demo-service")).expect("build");
-        builder
-            .push_request(RequestEvent {
-                request_id: "req-1".to_string(),
-                route: "route-a".to_string(),
-                kind: None,
-                started_at_unix_ms: 1,
-                started_at_run_us: None,
-                finished_at_unix_ms: 2,
-                finished_at_run_us: None,
-                latency_us: 1_000,
-                outcome: Outcome::Ok.into_string(),
-            })
-            .expect("push request");
-        builder.build()
     }
 
     fn unique_temp_output_path(prefix: &str) -> std::path::PathBuf {

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -96,6 +96,7 @@ tailtriage analyze tailtriage-run.json
 
 - Completed-span JSONL output contains retained original tracing source records selected after parsing, retention limits, and core normalization.
 - Source identity and source fields represented by `SpanRecord` are preserved exactly.
+- For custom tracing-like sources, construct the public adapter/input `SpanRecord` values with `SpanRecord::new(...)` and `with_*` methods, then pass them to `run_from_span_records(...)`; Tailtriage produces `ImportedRun` and `ImportWarning` outputs for accessor-based inspection rather than direct caller construction.
 - Direct input order and JSONL input order are preserved through replay; live session output is section-grouped as request records, then stage records, then queue records.
 - Replay parity is limited to representable normalized request/stage/queue evidence.
 - Completed-span JSONL does not encode Run-only metadata, runtime snapshots, in-flight snapshots, lifecycle warnings, semantic/raw truncation counters, source-line context, omitted-source diagnostics, or output failures.

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -33,10 +33,13 @@ class ValidateDocsContractsTests(unittest.TestCase):
     pub fn id(&self) {}
     pub fn with_id(mut self, id: String) -> Self { self }
 }
+impl SpanRecord {}
 impl ImportOptions {
     pub fn new() {}
     pub fn configured_run_id(&self) {}
+    pub fn is_strict(&self) {}
 }
+impl ImportOptions {}
 impl ImportWarning { pub(crate) fn new() {} }
 impl ImportedRun { pub(crate) fn new() {} }
 ''',
@@ -122,6 +125,39 @@ impl ImportedRun { pub(crate) fn new() {} }
                 self._assert_residual_api_rejected(
                     'tailtriage-tracing/src/types.rs', declaration + suffix, symbol
                 )
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_rejects_removed_tracing_surface_in_later_impls(self) -> None:
+        cases = (
+            ('''impl SpanRecord { pub fn id(&self) {} }
+impl SpanRecord { pub fn id(mut self, value: String) -> Self { self } }
+impl ImportOptions {}
+impl ImportWarning {}
+impl ImportedRun {}
+''', 'SpanRecord::id consuming setter'),
+            ('''impl SpanRecord {}
+impl ImportOptions { pub fn configured_run_id(&self) {} }
+impl ImportOptions { pub fn strict_mode(&self) -> bool { false } }
+impl ImportWarning {}
+impl ImportedRun {}
+''', 'ImportOptions::strict_mode'),
+        )
+        for source, symbol in cases:
+            with self.subTest(symbol=symbol):
+                self._assert_residual_api_rejected(
+                    'tailtriage-tracing/src/types.rs', source, symbol
+                )
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_rejects_const_removed_tracing_surface(self) -> None:
+        source = '''impl SpanRecord {}
+impl ImportOptions { pub const fn strict_mode(&self) -> bool { false } }
+impl ImportWarning {}
+impl ImportedRun {}
+'''
+        self._assert_residual_api_rejected(
+            'tailtriage-tracing/src/types.rs', source, 'ImportOptions::strict_mode'
+        )
 
     # TT-TEST: M02 secondary
     def test_residual_public_api_cleanup_accepts_canonical_tracing_surface(self) -> None:

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -28,6 +28,18 @@ class ValidateDocsContractsTests(unittest.TestCase):
             'tailtriage-analyzer/src/options/mod.rs': 'pub struct AnalyzeOptionDescriptor { path: &\'static str }\nimpl AnalyzeOptionDescriptor { pub(crate) fn new() {} }\n',
             'tailtriage-analyzer/src/options/overrides.rs': 'fn valid_override_paths() {}\npub(crate) fn valid_override_paths_for_crate() {}\n',
             'tailtriage-analyzer/src/lib.rs': 'pub enum DiagnosisKind { ApplicationQueuePressure, BlockingPoolPressure, ExecutorPressure, DownstreamStageDominance, InsufficientEvidence, }\n',
+            'tailtriage-tracing/src/types.rs': '''impl SpanRecord {
+    pub fn new() {}
+    pub fn id(&self) {}
+    pub fn with_id(mut self, id: String) -> Self { self }
+}
+impl ImportOptions {
+    pub fn new() {}
+    pub fn configured_run_id(&self) {}
+}
+impl ImportWarning { pub(crate) fn new() {} }
+impl ImportedRun { pub(crate) fn new() {} }
+''',
         }
         sources.update(overrides or {})
         for rel, body in sources.items():
@@ -94,6 +106,30 @@ class ValidateDocsContractsTests(unittest.TestCase):
     # TT-TEST: M02 secondary
     def test_residual_public_api_cleanup_rejects_removed_owned_request_method(self) -> None:
         self._assert_residual_api_rejected('tailtriage-core/src/collector.rs', 'pub fn begin_request_owned(&self) {}', 'Tailtriage::begin_request_owned')
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_rejects_removed_tracing_surface(self) -> None:
+        cases = (
+            ('impl SpanRecord { pub fn id(mut self, value: String) -> Self { self } }', 'SpanRecord::id consuming setter'),
+            ('impl SpanRecord { pub fn id_ref(&self) {} }', 'SpanRecord::id_ref'),
+            ('impl ImportOptions { pub fn strict_mode(&self) {} }', 'ImportOptions::strict_mode'),
+            ('impl ImportWarning { pub fn new() {} }', 'ImportWarning::new'),
+            ('impl ImportedRun { pub fn new() {} }', 'ImportedRun::new'),
+        )
+        suffix = '\nimpl SpanRecord {}\nimpl ImportOptions {}\nimpl ImportWarning {}\nimpl ImportedRun {}\n'
+        for declaration, symbol in cases:
+            with self.subTest(symbol=symbol):
+                self._assert_residual_api_rejected(
+                    'tailtriage-tracing/src/types.rs', declaration + suffix, symbol
+                )
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_accepts_canonical_tracing_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            self._write_residual_api_sources(root)
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
+                validate_docs_contracts.validate_residual_public_api_cleanup()
 
     # TT-TEST: M02 secondary
     def test_residual_public_api_cleanup_rejects_run_builder_finish(self) -> None:

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -30,10 +30,14 @@ class ValidateDocsContractsTests(unittest.TestCase):
             'tailtriage-analyzer/src/lib.rs': 'pub enum DiagnosisKind { ApplicationQueuePressure, BlockingPoolPressure, ExecutorPressure, DownstreamStageDominance, InsufficientEvidence, }\n',
             'tailtriage-tracing/src/types.rs': '''impl SpanRecord {
     pub fn new() {}
-    pub fn id(&self) {}
     pub fn with_id(mut self, id: String) -> Self { self }
 }
-impl SpanRecord {}
+impl SpanRecord
+where
+    (): Sized,
+{
+    pub fn id(&self) {}
+}
 impl ImportOptions {
     pub fn new() {}
     pub fn configured_run_id(&self) {}
@@ -147,6 +151,23 @@ impl ImportedRun {}
                 self._assert_residual_api_rejected(
                     'tailtriage-tracing/src/types.rs', source, symbol
                 )
+
+    # TT-TEST: M02 secondary
+    def test_residual_public_api_cleanup_rejects_removed_tracing_surface_in_where_impl(self) -> None:
+        source = '''impl SpanRecord {}
+impl SpanRecord
+where
+    (): Sized,
+{
+    pub fn id(mut self, value: String) -> Self { self }
+}
+impl ImportOptions {}
+impl ImportWarning {}
+impl ImportedRun {}
+'''
+        self._assert_residual_api_rejected(
+            'tailtriage-tracing/src/types.rs', source, 'SpanRecord::id consuming setter'
+        )
 
     # TT-TEST: M02 secondary
     def test_residual_public_api_cleanup_rejects_const_removed_tracing_surface(self) -> None:

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -554,20 +554,25 @@ def validate_residual_public_api_cleanup() -> None:
     tracing_types_path = REPO_ROOT / "tailtriage-tracing" / "src" / "types.rs"
     tracing_types_source = tracing_types_path.read_text(encoding="utf-8")
 
-    def impl_body(type_name: str) -> str:
-        declaration = re.search(rf"\bimpl\s+{type_name}\s*\{{", tracing_types_source)
-        if declaration is None:
+    def impl_bodies(type_name: str) -> tuple[str, ...]:
+        declarations = tuple(re.finditer(rf"\bimpl\s+{type_name}\s*\{{", tracing_types_source))
+        if not declarations:
             raise ValueError(f"{tracing_types_path.relative_to(REPO_ROOT)} missing impl {type_name}")
-        body_start = declaration.end()
-        depth = 1
-        for index in range(body_start, len(tracing_types_source)):
-            if tracing_types_source[index] == "{":
-                depth += 1
-            elif tracing_types_source[index] == "}":
-                depth -= 1
-                if depth == 0:
-                    return tracing_types_source[body_start:index]
-        raise ValueError(f"{tracing_types_path.relative_to(REPO_ROOT)} has unclosed impl {type_name}")
+        bodies = []
+        for declaration in declarations:
+            body_start = declaration.end()
+            depth = 1
+            for index in range(body_start, len(tracing_types_source)):
+                if tracing_types_source[index] == "{":
+                    depth += 1
+                elif tracing_types_source[index] == "}":
+                    depth -= 1
+                    if depth == 0:
+                        bodies.append(tracing_types_source[body_start:index])
+                        break
+            else:
+                raise ValueError(f"{tracing_types_path.relative_to(REPO_ROOT)} has unclosed impl {type_name}")
+        return tuple(bodies)
 
     tracing_removed_methods = {
         "SpanRecord": (
@@ -582,27 +587,28 @@ def validate_residual_public_api_cleanup() -> None:
             "service_version_ref", "run_id_ref", "strict_mode", "mode_value",
         ),
     }
-    span_body = impl_body("SpanRecord")
+    public_function = r"\bpub\s+(?:const\s+)?fn\s+"
+    span_bodies = impl_bodies("SpanRecord")
     consuming_names = (
         "id", "parent_id", "field", "started_at_run_us", "finished_at_run_us", "duration_us",
     )
     for name in consuming_names:
-        pattern = rf"\bpub\s+fn\s+{name}\s*\(\s*(?:mut\s+)?self\b"
-        if re.search(pattern, span_body):
+        pattern = rf"{public_function}{name}\s*\(\s*(?:mut\s+)?self\b"
+        if any(re.search(pattern, body) for body in span_bodies):
             raise ValueError(
                 f"{tracing_types_path.relative_to(REPO_ROOT)} exposes removed residual public API: SpanRecord::{name} consuming setter"
             )
     for type_name, names in tracing_removed_methods.items():
-        body = impl_body(type_name)
+        bodies = impl_bodies(type_name)
         for name in names:
             if name.endswith(" consuming setter"):
                 continue
-            if re.search(rf"\bpub\s+fn\s+{name}\s*\(", body):
+            if any(re.search(rf"{public_function}{name}\s*\(", body) for body in bodies):
                 raise ValueError(
                     f"{tracing_types_path.relative_to(REPO_ROOT)} exposes removed residual public API: {type_name}::{name}"
                 )
     for type_name in ("ImportWarning", "ImportedRun"):
-        if re.search(r"\bpub\s+fn\s+new\s*\(", impl_body(type_name)):
+        if any(re.search(rf"{public_function}new\s*\(", body) for body in impl_bodies(type_name)):
             raise ValueError(
                 f"{tracing_types_path.relative_to(REPO_ROOT)} exposes removed residual public API: {type_name}::new"
             )

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -551,6 +551,62 @@ def validate_residual_public_api_cleanup() -> None:
                     f"{path.relative_to(REPO_ROOT)} exposes removed residual public API: {symbol}"
                 )
 
+    tracing_types_path = REPO_ROOT / "tailtriage-tracing" / "src" / "types.rs"
+    tracing_types_source = tracing_types_path.read_text(encoding="utf-8")
+
+    def impl_body(type_name: str) -> str:
+        declaration = re.search(rf"\bimpl\s+{type_name}\s*\{{", tracing_types_source)
+        if declaration is None:
+            raise ValueError(f"{tracing_types_path.relative_to(REPO_ROOT)} missing impl {type_name}")
+        body_start = declaration.end()
+        depth = 1
+        for index in range(body_start, len(tracing_types_source)):
+            if tracing_types_source[index] == "{":
+                depth += 1
+            elif tracing_types_source[index] == "}":
+                depth -= 1
+                if depth == 0:
+                    return tracing_types_source[body_start:index]
+        raise ValueError(f"{tracing_types_path.relative_to(REPO_ROOT)} has unclosed impl {type_name}")
+
+    tracing_removed_methods = {
+        "SpanRecord": (
+            *(f"{name} consuming setter" for name in (
+                "id", "parent_id", "field", "started_at_run_us",
+                "finished_at_run_us", "duration_us",
+            )),
+            "id_ref", "parent_id_ref", "started_at_run_us_ref",
+            "finished_at_run_us_ref", "duration_us_ref",
+        ),
+        "ImportOptions": (
+            "service_version_ref", "run_id_ref", "strict_mode", "mode_value",
+        ),
+    }
+    span_body = impl_body("SpanRecord")
+    consuming_names = (
+        "id", "parent_id", "field", "started_at_run_us", "finished_at_run_us", "duration_us",
+    )
+    for name in consuming_names:
+        pattern = rf"\bpub\s+fn\s+{name}\s*\(\s*(?:mut\s+)?self\b"
+        if re.search(pattern, span_body):
+            raise ValueError(
+                f"{tracing_types_path.relative_to(REPO_ROOT)} exposes removed residual public API: SpanRecord::{name} consuming setter"
+            )
+    for type_name, names in tracing_removed_methods.items():
+        body = impl_body(type_name)
+        for name in names:
+            if name.endswith(" consuming setter"):
+                continue
+            if re.search(rf"\bpub\s+fn\s+{name}\s*\(", body):
+                raise ValueError(
+                    f"{tracing_types_path.relative_to(REPO_ROOT)} exposes removed residual public API: {type_name}::{name}"
+                )
+    for type_name in ("ImportWarning", "ImportedRun"):
+        if re.search(r"\bpub\s+fn\s+new\s*\(", impl_body(type_name)):
+            raise ValueError(
+                f"{tracing_types_path.relative_to(REPO_ROOT)} exposes removed residual public API: {type_name}::new"
+            )
+
     analyzer_path = REPO_ROOT / "tailtriage-analyzer" / "src" / "lib.rs"
     analyzer_source = analyzer_path.read_text(encoding="utf-8")
     diagnosis_kind = re.search(

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -555,7 +555,11 @@ def validate_residual_public_api_cleanup() -> None:
     tracing_types_source = tracing_types_path.read_text(encoding="utf-8")
 
     def impl_bodies(type_name: str) -> tuple[str, ...]:
-        declarations = tuple(re.finditer(rf"\bimpl\s+{type_name}\s*\{{", tracing_types_source))
+        declarations = tuple(re.finditer(
+            rf"\bimpl\s+{type_name}\s*(?:where\b[^{{]*?)?\{{",
+            tracing_types_source,
+            re.DOTALL,
+        ))
         if not declarations:
             raise ValueError(f"{tracing_types_path.relative_to(REPO_ROOT)} missing impl {type_name}")
         bodies = []

--- a/tailtriage-cli/tests/json_parity.rs
+++ b/tailtriage-cli/tests/json_parity.rs
@@ -881,40 +881,40 @@ fn tracing_candidates() -> Vec<TracingCase> {
 
 fn req(id: &str, start: u64, end: u64, dur: u64) -> tailtriage_tracing::SpanRecord {
     tailtriage_tracing::SpanRecord::new("req", 1, 2)
-        .field(tailtriage_tracing::TT_KIND, "request")
-        .field(tailtriage_tracing::TT_REQUEST_ID, id)
-        .field(tailtriage_tracing::TT_ROUTE, "/")
-        .field(tailtriage_tracing::TT_OUTCOME, "ok")
-        .started_at_run_us(start)
-        .finished_at_run_us(end)
-        .duration_us(dur)
+        .with_field(tailtriage_tracing::TT_KIND, "request")
+        .with_field(tailtriage_tracing::TT_REQUEST_ID, id)
+        .with_field(tailtriage_tracing::TT_ROUTE, "/")
+        .with_field(tailtriage_tracing::TT_OUTCOME, "ok")
+        .with_started_at_run_us(start)
+        .with_finished_at_run_us(end)
+        .with_duration_us(dur)
 }
 fn req_no_precision(id: &str, dur: u64) -> tailtriage_tracing::SpanRecord {
     tailtriage_tracing::SpanRecord::new("req", 1, 2)
-        .field(tailtriage_tracing::TT_KIND, "request")
-        .field(tailtriage_tracing::TT_REQUEST_ID, id)
-        .field(tailtriage_tracing::TT_ROUTE, "/")
-        .field(tailtriage_tracing::TT_OUTCOME, "ok")
-        .duration_us(dur)
+        .with_field(tailtriage_tracing::TT_KIND, "request")
+        .with_field(tailtriage_tracing::TT_REQUEST_ID, id)
+        .with_field(tailtriage_tracing::TT_ROUTE, "/")
+        .with_field(tailtriage_tracing::TT_OUTCOME, "ok")
+        .with_duration_us(dur)
 }
 fn stage(id: &str, start: u64, end: u64, dur: u64) -> tailtriage_tracing::SpanRecord {
     tailtriage_tracing::SpanRecord::new("stage", 1, 2)
-        .field(tailtriage_tracing::TT_KIND, "stage")
-        .field(tailtriage_tracing::TT_REQUEST_ID, id)
-        .field(tailtriage_tracing::TT_STAGE, "db")
-        .field(tailtriage_tracing::TT_SUCCESS, true)
-        .started_at_run_us(start)
-        .finished_at_run_us(end)
-        .duration_us(dur)
+        .with_field(tailtriage_tracing::TT_KIND, "stage")
+        .with_field(tailtriage_tracing::TT_REQUEST_ID, id)
+        .with_field(tailtriage_tracing::TT_STAGE, "db")
+        .with_field(tailtriage_tracing::TT_SUCCESS, true)
+        .with_started_at_run_us(start)
+        .with_finished_at_run_us(end)
+        .with_duration_us(dur)
 }
 fn queue(id: &str, start: u64, end: u64, dur: u64) -> tailtriage_tracing::SpanRecord {
     tailtriage_tracing::SpanRecord::new("queue", 1, 2)
-        .field(tailtriage_tracing::TT_KIND, "queue")
-        .field(tailtriage_tracing::TT_REQUEST_ID, id)
-        .field(tailtriage_tracing::TT_QUEUE, "pool")
-        .started_at_run_us(start)
-        .finished_at_run_us(end)
-        .duration_us(dur)
+        .with_field(tailtriage_tracing::TT_KIND, "queue")
+        .with_field(tailtriage_tracing::TT_REQUEST_ID, id)
+        .with_field(tailtriage_tracing::TT_QUEUE, "pool")
+        .with_started_at_run_us(start)
+        .with_finished_at_run_us(end)
+        .with_duration_us(dur)
 }
 fn spans_for(name: &str) -> Vec<tailtriage_tracing::SpanRecord> {
     match name {
@@ -926,16 +926,16 @@ fn spans_for(name: &str) -> Vec<tailtriage_tracing::SpanRecord> {
         "missing-precision" => vec![
             req_no_precision("req1", 10),
             tailtriage_tracing::SpanRecord::new("stage", 1, 2)
-                .field(tailtriage_tracing::TT_KIND, "stage")
-                .field(tailtriage_tracing::TT_REQUEST_ID, "req1")
-                .field(tailtriage_tracing::TT_STAGE, "db")
-                .field(tailtriage_tracing::TT_SUCCESS, true)
-                .duration_us(3),
+                .with_field(tailtriage_tracing::TT_KIND, "stage")
+                .with_field(tailtriage_tracing::TT_REQUEST_ID, "req1")
+                .with_field(tailtriage_tracing::TT_STAGE, "db")
+                .with_field(tailtriage_tracing::TT_SUCCESS, true)
+                .with_duration_us(3),
             tailtriage_tracing::SpanRecord::new("queue", 1, 2)
-                .field(tailtriage_tracing::TT_KIND, "queue")
-                .field(tailtriage_tracing::TT_REQUEST_ID, "req1")
-                .field(tailtriage_tracing::TT_QUEUE, "pool")
-                .duration_us(2),
+                .with_field(tailtriage_tracing::TT_KIND, "queue")
+                .with_field(tailtriage_tracing::TT_REQUEST_ID, "req1")
+                .with_field(tailtriage_tracing::TT_QUEUE, "pool")
+                .with_duration_us(2),
         ],
         "duplicate-ambiguous-child" => vec![
             req("dup", 0, 10, 10),
@@ -944,12 +944,12 @@ fn spans_for(name: &str) -> Vec<tailtriage_tracing::SpanRecord> {
         ],
         "orphan-child" => vec![req("req1", 1, 11, 10), stage("missing", 1, 2, 1)],
         "invalid-optional-precision" => vec![tailtriage_tracing::SpanRecord::new("req", 1, 2)
-            .field(tailtriage_tracing::TT_KIND, "request")
-            .field(tailtriage_tracing::TT_REQUEST_ID, "req1")
-            .field(tailtriage_tracing::TT_ROUTE, "/")
-            .field(tailtriage_tracing::TT_OUTCOME, "ok")
-            .started_at_run_us(1)
-            .duration_us(10)],
+            .with_field(tailtriage_tracing::TT_KIND, "request")
+            .with_field(tailtriage_tracing::TT_REQUEST_ID, "req1")
+            .with_field(tailtriage_tracing::TT_ROUTE, "/")
+            .with_field(tailtriage_tracing::TT_OUTCOME, "ok")
+            .with_started_at_run_us(1)
+            .with_duration_us(10)],
         "outside-child" => vec![req("req1", 10, 20, 10), stage("req1", 0, 5, 5)],
         _ => unreachable!(),
     }

--- a/tailtriage-tracing/README.md
+++ b/tailtriage-tracing/README.md
@@ -33,6 +33,40 @@ CLI offline import workflows only need JSONL import support and do not require t
 
 The same APIs are also available through the default `tailtriage` crate when enabling its `tracing`, `tracing-live`, or `tracing-tokio` façade features.
 
+## Custom tracing-like sources
+
+`SpanRecord` is the public adapter/input type for custom tracing-like sources. Construct records with `SpanRecord::new(...)` and its `with_*` methods, then pass them to `run_from_span_records(...)`:
+
+```rust
+use tailtriage_tracing::{
+    run_from_span_records, ImportOptions, SpanRecord, TT_KIND, TT_REQUEST_ID, TT_ROUTE,
+};
+
+let record = SpanRecord::new("request", 10, 20)
+    .with_id("span-1")
+    .with_started_at_run_us(100)
+    .with_finished_at_run_us(200)
+    .with_duration_us(100)
+    .with_field(TT_KIND, "request")
+    .with_field(TT_REQUEST_ID, "req-1")
+    .with_field(TT_ROUTE, "/checkout");
+
+let imported = run_from_span_records(
+    [record],
+    ImportOptions::new("checkout-service")
+        .service_version("1.2.3")
+        .run_id("run-123")
+        .strict(false)
+        .mode(tailtriage_core::CaptureMode::Light),
+)?;
+
+assert_eq!(imported.run().metadata.service_name, "checkout-service");
+let _warnings = imported.warnings();
+# Ok::<(), tailtriage_tracing::ImportError>(())
+```
+
+`ImportedRun` and `ImportWarning` are output types produced by Tailtriage. Inspect them through their public accessors; direct construction of those result values is not the supported boundary.
+
 For live tracing intake sessions, `tailtriage-tracing` enables optional dependencies behind feature flags, but applications that call `tracing::...` or `tracing_subscriber::...` directly still need explicit app dependencies:
 
 ```bash

--- a/tailtriage-tracing/src/jsonl.rs
+++ b/tailtriage-tracing/src/jsonl.rs
@@ -34,7 +34,7 @@ fn import_jsonl_reader_with_limit<R: Read>(
     record_limit: usize,
 ) -> Result<ImportedRun, ImportError> {
     let mut parse_warnings = Vec::new();
-    let strict = options.strict_mode();
+    let strict = options.is_strict();
     let records = BoundedJsonlRecords::new(reader, record_limit);
     let spans = records.filter_map(|record| match record {
         Err(error) => Some(Err(error)),
@@ -587,29 +587,29 @@ mod tests {
     #[test]
     fn stable_writer_output_reimports_with_explicit_evidence() {
         let span = SpanRecord::new("http.request", 1000, 1100)
-            .id("span-id")
-            .parent_id("parent-id")
-            .started_at_run_us(10)
-            .finished_at_run_us(100_010)
-            .duration_us(100_000)
-            .field(crate::TT_KIND, "request")
-            .field(crate::TT_REQUEST_ID, "req-1")
-            .field(crate::TT_ROUTE, "/checkout")
-            .field("custom", "kept");
+            .with_id("span-id")
+            .with_parent_id("parent-id")
+            .with_started_at_run_us(10)
+            .with_finished_at_run_us(100_010)
+            .with_duration_us(100_000)
+            .with_field(crate::TT_KIND, "request")
+            .with_field(crate::TT_REQUEST_ID, "req-1")
+            .with_field(crate::TT_ROUTE, "/checkout")
+            .with_field("custom", "kept");
         let jsonl =
             serde_json::json!({"format":"tailtriage.tracing-span.v1","span":span}).to_string();
         let imported = import_jsonl_reader(Cursor::new(jsonl), ImportOptions::new("svc")).unwrap();
         let retained = imported.retained_sources();
         assert_eq!(retained.len(), 1);
         let source = &retained[0];
-        assert_eq!(source.id_ref(), Some("span-id"));
-        assert_eq!(source.parent_id_ref(), Some("parent-id"));
+        assert_eq!(source.id(), Some("span-id"));
+        assert_eq!(source.parent_id(), Some("parent-id"));
         assert_eq!(source.name(), "http.request");
         assert_eq!(source.started_at_unix_ms(), 1000);
         assert_eq!(source.finished_at_unix_ms(), 1100);
-        assert_eq!(source.started_at_run_us_ref(), Some(10));
-        assert_eq!(source.finished_at_run_us_ref(), Some(100_010));
-        assert_eq!(source.duration_us_ref(), Some(100_000));
+        assert_eq!(source.started_at_run_us(), Some(10));
+        assert_eq!(source.finished_at_run_us(), Some(100_010));
+        assert_eq!(source.duration_us(), Some(100_000));
         assert_eq!(
             source.fields().get(crate::TT_KIND),
             Some(&FieldValue::String("request".to_owned()))

--- a/tailtriage-tracing/src/lib.rs
+++ b/tailtriage-tracing/src/lib.rs
@@ -12,22 +12,51 @@
 //! tracing-specific analyzer path; Run JSON and the existing analyzer remain the
 //! center of the workflow.
 //!
-//! # Example
+//! # Custom-source example
+//!
+//! [`SpanRecord`] is the public adapter/input type for custom tracing-like sources.
+//! Construct records and pass them to [`run_from_span_records`]; Tailtriage produces
+//! [`ImportedRun`] and [`ImportWarning`] result values for inspection through their
+//! public accessors rather than direct caller construction.
 //!
 //! ```
 //! use tailtriage_tracing::{
-//!     ImportOptions, SpanRecord, TT_KIND, TT_OUTCOME, TT_REQUEST_ID, TT_ROUTE,
+//!     run_from_span_records, ImportOptions, SpanRecord, TT_KIND, TT_REQUEST_ID, TT_ROUTE,
 //! };
 //!
-//! let record = SpanRecord::new("http.request", 1_700_000_000_000, 1_700_000_000_120)
-//!     .field(TT_KIND, "request")
-//!     .field(TT_REQUEST_ID, "req-42")
-//!     .field(TT_ROUTE, "/checkout")
-//!     .field(TT_OUTCOME, "ok");
+//! # fn example() -> Result<(), tailtriage_tracing::ImportError> {
+//! let record = SpanRecord::new("request", 10, 20)
+//!     .with_id("span-1")
+//!     .with_parent_id("parent-1")
+//!     .with_started_at_run_us(100)
+//!     .with_finished_at_run_us(200)
+//!     .with_duration_us(100)
+//!     .with_field(TT_KIND, "request")
+//!     .with_field(TT_REQUEST_ID, "req-1")
+//!     .with_field(TT_ROUTE, "/checkout");
 //!
-//! let options = ImportOptions::new("checkout-service").strict(false);
-//! assert_eq!(record.name(), "http.request");
-//! assert_eq!(options.service_name(), "checkout-service");
+//! assert_eq!(record.id(), Some("span-1"));
+//! assert_eq!(record.parent_id(), Some("parent-1"));
+//! assert_eq!(record.started_at_run_us(), Some(100));
+//! assert_eq!(record.finished_at_run_us(), Some(200));
+//! assert_eq!(record.duration_us(), Some(100));
+//!
+//! let options = ImportOptions::new("checkout-service")
+//!     .service_version("1.2.3")
+//!     .run_id("run-123")
+//!     .strict(false)
+//!     .mode(tailtriage_core::CaptureMode::Light);
+//! assert_eq!(options.configured_service_version(), Some("1.2.3"));
+//! assert_eq!(options.configured_run_id(), Some("run-123"));
+//! assert!(!options.is_strict());
+//! assert_eq!(options.capture_mode(), tailtriage_core::CaptureMode::Light);
+//!
+//! let imported = run_from_span_records([record], options)?;
+//! assert_eq!(imported.run().metadata.service_name, "checkout-service");
+//! let _warnings = imported.warnings();
+//! # Ok(())
+//! # }
+//! # example().unwrap();
 //! ```
 
 mod convention;
@@ -189,7 +218,7 @@ where
             StringFieldState::Missing => {
                 if span_has_tailtriage_field(span) {
                     strict_or_warn(
-                        options.strict_mode(),
+                        options.is_strict(),
                         &mut warnings,
                         format!(
                             "missing required field '{TT_KIND}' in span '{}'",
@@ -202,7 +231,7 @@ where
             StringFieldState::Value(kind) => {
                 let Some(kind) = SpanKind::parse(kind) else {
                     strict_or_warn(
-                        options.strict_mode(),
+                        options.is_strict(),
                         &mut warnings,
                         format!("unknown tt.kind '{kind}' in span '{}'", span.name()),
                     )?;
@@ -212,7 +241,7 @@ where
             }
             StringFieldState::InvalidType => {
                 strict_or_warn(
-                    options.strict_mode(),
+                    options.is_strict(),
                     &mut warnings,
                     format!(
                         "invalid field '{TT_KIND}' in span '{}': expected string",
@@ -225,7 +254,7 @@ where
 
         if span.finished_at_unix_ms() < span.started_at_unix_ms() {
             strict_or_warn(
-                options.strict_mode(),
+                options.is_strict(),
                 &mut warnings,
                 format!(
                     "skipped span '{}' due to inverted timestamps: start={} finish={}",
@@ -240,11 +269,11 @@ where
         match kind {
             SpanKind::Request => {
                 let request_id =
-                    required_string(span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
-                let route = required_string(span, TT_ROUTE, options.strict_mode(), &mut warnings)?;
+                    required_string(span, TT_REQUEST_ID, options.is_strict(), &mut warnings)?;
+                let route = required_string(span, TT_ROUTE, options.is_strict(), &mut warnings)?;
                 if let (Some(request_id), Some(route)) = (request_id, route) {
                     let Some((outcome, outcome_defaulted)) =
-                        parse_outcome(span, options.strict_mode(), &mut warnings)?
+                        parse_outcome(span, options.is_strict(), &mut warnings)?
                     else {
                         continue;
                     };
@@ -288,10 +317,10 @@ where
             }
             SpanKind::Stage => {
                 let request_id =
-                    required_string(span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
-                let stage = required_string(span, TT_STAGE, options.strict_mode(), &mut warnings)?;
+                    required_string(span, TT_REQUEST_ID, options.is_strict(), &mut warnings)?;
+                let stage = required_string(span, TT_STAGE, options.is_strict(), &mut warnings)?;
                 if let (Some(request_id), Some(stage)) = (request_id, stage) {
-                    let success_field = parse_success(span, options.strict_mode(), &mut warnings)?;
+                    let success_field = parse_success(span, options.is_strict(), &mut warnings)?;
                     let success = match success_field {
                         OptionalField::Missing => true,
                         OptionalField::Value(success) => success,
@@ -337,11 +366,11 @@ where
             }
             SpanKind::Queue => {
                 let request_id =
-                    required_string(span, TT_REQUEST_ID, options.strict_mode(), &mut warnings)?;
-                let queue = required_string(span, TT_QUEUE, options.strict_mode(), &mut warnings)?;
+                    required_string(span, TT_REQUEST_ID, options.is_strict(), &mut warnings)?;
+                let queue = required_string(span, TT_QUEUE, options.is_strict(), &mut warnings)?;
                 if let (Some(request_id), Some(queue)) = (request_id, queue) {
                     let depth_at_start =
-                        match parse_depth_at_start(span, options.strict_mode(), &mut warnings)? {
+                        match parse_depth_at_start(span, options.is_strict(), &mut warnings)? {
                             OptionalField::Missing => None,
                             OptionalField::Value(depth) => Some(depth),
                             OptionalField::Invalid => continue,
@@ -385,7 +414,7 @@ where
             }
         }
     }
-    let mode = options.mode_value();
+    let mode = options.capture_mode();
 
     let request_outcome_default_count = parsed_requests
         .iter()
@@ -426,8 +455,8 @@ where
             let now = tailtriage_core::unix_time_ms();
             (now, now)
         });
-    let explicit_run_id = options.run_id_ref().is_some();
-    let run_id = options.run_id_ref().map_or_else(
+    let explicit_run_id = options.configured_run_id().is_some();
+    let run_id = options.configured_run_id().map_or_else(
         || format!("tracing-import-{started_at_unix_ms}-{finished_at_unix_ms}"),
         ToOwned::to_owned,
     );
@@ -437,7 +466,7 @@ where
         metadata: RunMetadata {
             run_id,
             service_name: options.service_name().to_owned(),
-            service_version: options.service_version_ref().map(ToOwned::to_owned),
+            service_version: options.configured_service_version().map(ToOwned::to_owned),
             started_at_unix_ms,
             finalized_at_unix_ms: Some(finished_at_unix_ms),
             mode,
@@ -461,7 +490,7 @@ where
         truncation,
     };
 
-    if options.strict_mode() {
+    if options.is_strict() {
         validate_run_strict(&candidate).map_err(|err| strict_core_error(&err))?;
     }
 
@@ -850,7 +879,7 @@ fn timestamp_derived_duration_us(started_at_unix_ms: u64, finished_at_unix_ms: u
 }
 
 fn sanitized_run_relative_offsets(span: &SpanRecord) -> (Option<u64>, Option<u64>) {
-    (span.started_at_run_us_ref(), span.finished_at_run_us_ref())
+    (span.started_at_run_us(), span.finished_at_run_us())
 }
 
 fn run_relative_derived_duration_us(
@@ -867,7 +896,7 @@ fn elapsed_duration_us(
     started_at_run_us: Option<u64>,
     finished_at_run_us: Option<u64>,
 ) -> u64 {
-    if let Some(duration_us) = span.duration_us_ref() {
+    if let Some(duration_us) = span.duration_us() {
         return duration_us;
     }
 
@@ -1054,25 +1083,25 @@ mod tests {
         for index in 0..4 {
             spans.push(
                 SpanRecord::new(format!("request-{index}"), 1, 2)
-                    .field(TT_KIND, "request")
-                    .field(TT_REQUEST_ID, format!("r{index}"))
-                    .field(TT_ROUTE, "/bounded"),
+                    .with_field(TT_KIND, "request")
+                    .with_field(TT_REQUEST_ID, format!("r{index}"))
+                    .with_field(TT_ROUTE, "/bounded"),
             );
         }
         for index in 0..4 {
             spans.push(
                 SpanRecord::new(format!("stage-{index}"), 1, 2)
-                    .field(TT_KIND, "stage")
-                    .field(TT_REQUEST_ID, "r0")
-                    .field(TT_STAGE, format!("s{index}")),
+                    .with_field(TT_KIND, "stage")
+                    .with_field(TT_REQUEST_ID, "r0")
+                    .with_field(TT_STAGE, format!("s{index}")),
             );
         }
         for index in 0..4 {
             spans.push(
                 SpanRecord::new(format!("queue-{index}"), 1, 2)
-                    .field(TT_KIND, "queue")
-                    .field(TT_REQUEST_ID, "r0")
-                    .field(TT_QUEUE, format!("q{index}")),
+                    .with_field(TT_KIND, "queue")
+                    .with_field(TT_REQUEST_ID, "r0")
+                    .with_field(TT_QUEUE, format!("q{index}")),
             );
         }
         let converted = convert_span_records_with_provenance(
@@ -1152,23 +1181,23 @@ mod tests {
 
     fn req(id: &str, start: u64, finish: u64) -> SpanRecord {
         SpanRecord::new(format!("req-{id}"), start, finish)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, id)
-            .field(TT_ROUTE, "/")
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, id)
+            .with_field(TT_ROUTE, "/")
     }
 
     fn stage(id: &str, name: &str, start: u64, finish: u64) -> SpanRecord {
         SpanRecord::new(format!("stage-{name}"), start, finish)
-            .field(TT_KIND, "stage")
-            .field(TT_REQUEST_ID, id)
-            .field(TT_STAGE, name)
+            .with_field(TT_KIND, "stage")
+            .with_field(TT_REQUEST_ID, id)
+            .with_field(TT_STAGE, name)
     }
 
     fn queue(id: &str, name: &str, start: u64, finish: u64) -> SpanRecord {
         SpanRecord::new(format!("queue-{name}"), start, finish)
-            .field(TT_KIND, "queue")
-            .field(TT_REQUEST_ID, id)
-            .field(TT_QUEUE, name)
+            .with_field(TT_KIND, "queue")
+            .with_field(TT_REQUEST_ID, id)
+            .with_field(TT_QUEUE, name)
     }
 
     fn empty_candidate_run() -> Run {
@@ -1258,8 +1287,8 @@ mod tests {
             .map(|span| {
                 (
                     span.name().to_owned(),
-                    span.id_ref().unwrap_or_default().to_owned(),
-                    span.parent_id_ref().unwrap_or_default().to_owned(),
+                    span.id().unwrap_or_default().to_owned(),
+                    span.parent_id().unwrap_or_default().to_owned(),
                 )
             })
             .collect()
@@ -1295,18 +1324,18 @@ mod tests {
     #[test]
     fn imported_run_privately_carries_exact_retained_original_sources() {
         let request = req("a", 100, 120)
-            .id("req-span")
-            .parent_id("root")
-            .started_at_run_us(10)
-            .finished_at_run_us(30)
-            .duration_us(20_000)
-            .field("custom", 7_u64);
+            .with_id("req-span")
+            .with_parent_id("root")
+            .with_started_at_run_us(10)
+            .with_finished_at_run_us(30)
+            .with_duration_us(20_000)
+            .with_field("custom", 7_u64);
         let child = stage("a", "db", 105, 110)
-            .id("stage-span")
-            .parent_id("req-span")
-            .started_at_run_us(15)
-            .finished_at_run_us(20)
-            .duration_us(5_000);
+            .with_id("stage-span")
+            .with_parent_id("req-span")
+            .with_started_at_run_us(15)
+            .with_finished_at_run_us(20)
+            .with_duration_us(5_000);
         let imported = run_from_span_records(vec![request.clone(), child.clone()], opts()).unwrap();
 
         assert_eq!(
@@ -1587,11 +1616,17 @@ mod tests {
     #[test]
     fn provenance_retained_sources_follow_original_source_order_not_canonical_sections() {
         let spans = vec![
-            stage("r1", "s1", 101, 102).id("stage-1").parent_id("req-1"),
-            req("r1", 100, 120).id("req-1"),
-            queue("r1", "q1", 103, 104).id("queue-1").parent_id("req-1"),
-            stage("r1", "s2", 105, 106).id("stage-2").parent_id("req-1"),
-            req("r2", 200, 220).id("req-2"),
+            stage("r1", "s1", 101, 102)
+                .with_id("stage-1")
+                .with_parent_id("req-1"),
+            req("r1", 100, 120).with_id("req-1"),
+            queue("r1", "q1", 103, 104)
+                .with_id("queue-1")
+                .with_parent_id("req-1"),
+            stage("r1", "s2", 105, 106)
+                .with_id("stage-2")
+                .with_parent_id("req-1"),
+            req("r2", 200, 220).with_id("req-2"),
         ];
 
         let result = convert_span_records_with_provenance(spans, opts()).unwrap();
@@ -1639,11 +1674,11 @@ mod tests {
             stage("dup", "ambiguous", 135, 140),
             stage("orphan", "orphan", 200, 210),
             req("precise", 400, 420)
-                .started_at_run_us(0)
-                .finished_at_run_us(20_000),
+                .with_started_at_run_us(0)
+                .with_finished_at_run_us(20_000),
             stage("precise", "outside", 400, 430)
-                .started_at_run_us(0)
-                .finished_at_run_us(30_000),
+                .with_started_at_run_us(0)
+                .with_finished_at_run_us(30_000),
         ];
 
         let result = convert_span_records_with_provenance(spans, opts()).unwrap();
@@ -1670,15 +1705,15 @@ mod tests {
     #[test]
     fn provenance_never_revives_source_parsing_drops() {
         let spans = vec![
-            SpanRecord::new("unsupported-kind", 90, 91).field(TT_KIND, "unsupported"),
+            SpanRecord::new("unsupported-kind", 90, 91).with_field(TT_KIND, "unsupported"),
             req("r", 100, 120)
-                .started_at_run_us(0)
-                .finished_at_run_us(20_000)
-                .field(TT_OUTCOME, "ok"),
+                .with_started_at_run_us(0)
+                .with_finished_at_run_us(20_000)
+                .with_field(TT_OUTCOME, "ok"),
             stage("r", "s", 101, 102)
-                .started_at_run_us(1_000)
-                .finished_at_run_us(2_000)
-                .field(TT_SUCCESS, true),
+                .with_started_at_run_us(1_000)
+                .with_finished_at_run_us(2_000)
+                .with_field(TT_SUCCESS, true),
         ];
 
         let result = convert_span_records_with_provenance(spans, opts()).unwrap();
@@ -1721,16 +1756,16 @@ mod tests {
         assert_eq!(missing_result.retained_sources, missing);
 
         let repaired_req = req("r", 100, 120)
-            .started_at_run_us(0)
-            .finished_at_run_us(10)
-            .duration_us(20_000);
+            .with_started_at_run_us(0)
+            .with_finished_at_run_us(10)
+            .with_duration_us(20_000);
         let repaired_stage = stage("r", "db", 105, 115)
-            .started_at_run_us(5_000)
-            .duration_us(10_000);
+            .with_started_at_run_us(5_000)
+            .with_duration_us(10_000);
         let repaired_queue = queue("r", "work", 106, 107)
-            .started_at_run_us(6_000)
-            .finished_at_run_us(6_500)
-            .duration_us(10_000);
+            .with_started_at_run_us(6_000)
+            .with_finished_at_run_us(6_500)
+            .with_duration_us(10_000);
         let repaired = vec![repaired_req, repaired_stage, repaired_queue];
         let repaired_result =
             convert_span_records_with_provenance(repaired.clone(), opts()).unwrap();
@@ -1759,11 +1794,11 @@ mod tests {
             stage("dup", "ambiguous", 135, 140),
             stage("orphan", "orphan", 200, 210),
             req("bad", 300, 320)
-                .started_at_run_us(0)
-                .finished_at_run_us(20_000),
+                .with_started_at_run_us(0)
+                .with_finished_at_run_us(20_000),
             stage("bad", "outside", 300, 330)
-                .started_at_run_us(0)
-                .finished_at_run_us(30_000),
+                .with_started_at_run_us(0)
+                .with_finished_at_run_us(30_000),
         ];
         let result = convert_span_records_with_provenance(spans, opts()).unwrap();
         assert_eq!(retained_indices(&result), vec![4]);
@@ -1901,9 +1936,9 @@ mod tests {
     #[test]
     fn request_only_conversion_creates_one_request_event() {
         let spans = vec![SpanRecord::new("req", 100, 110)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).expect("ok");
         assert_eq!(imported.run().requests.len(), 1);
     }
@@ -1913,15 +1948,15 @@ mod tests {
     fn request_and_stage_convert() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .started_at_run_us(100_000)
-                .finished_at_run_us(120_000)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_started_at_run_us(100_000)
+                .with_finished_at_run_us(120_000)
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st", 105, 115)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -1936,15 +1971,15 @@ mod tests {
     fn request_and_queue_convert() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .started_at_run_us(100_000)
-                .finished_at_run_us(120_000)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_started_at_run_us(100_000)
+                .with_finished_at_run_us(120_000)
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 102, 103)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -1958,26 +1993,26 @@ mod tests {
     fn span_record_run_relative_fields_convert_to_core_events() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .started_at_run_us(10)
-                .finished_at_run_us(20_010)
-                .duration_us(20_000)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_started_at_run_us(10)
+                .with_finished_at_run_us(20_010)
+                .with_duration_us(20_000)
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st", 105, 115)
-                .started_at_run_us(5_010)
-                .finished_at_run_us(15_010)
-                .duration_us(10_000)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_started_at_run_us(5_010)
+                .with_finished_at_run_us(15_010)
+                .with_duration_us(10_000)
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("q", 102, 103)
-                .started_at_run_us(2_010)
-                .finished_at_run_us(3_010)
-                .duration_us(1_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_started_at_run_us(2_010)
+                .with_finished_at_run_us(3_010)
+                .with_duration_us(1_000)
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -1996,11 +2031,11 @@ mod tests {
     #[test]
     fn missing_duration_uses_run_relative_delta_before_unix_bounds() {
         let spans = vec![SpanRecord::new("req", 10, 11)
-            .started_at_run_us(1_000)
-            .finished_at_run_us(51_000)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_started_at_run_us(1_000)
+            .with_finished_at_run_us(51_000)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
 
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
 
@@ -2011,12 +2046,12 @@ mod tests {
     #[test]
     fn strict_duration_matching_run_relative_allows_wall_clock_mismatch() {
         let spans = vec![SpanRecord::new("req", 10, 11)
-            .started_at_run_us(1_000)
-            .finished_at_run_us(51_000)
-            .duration_us(50_000)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_started_at_run_us(1_000)
+            .with_finished_at_run_us(51_000)
+            .with_duration_us(50_000)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
 
         let imported =
             run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap();
@@ -2028,12 +2063,12 @@ mod tests {
     #[test]
     fn strict_duration_mismatching_run_relative_fails_even_if_unix_matches() {
         let spans = vec![SpanRecord::new("req", 10, 60)
-            .started_at_run_us(1_000)
-            .finished_at_run_us(11_000)
-            .duration_us(50_000)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_started_at_run_us(1_000)
+            .with_finished_at_run_us(11_000)
+            .with_duration_us(50_000)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
 
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
             .expect_err("strict import should reject duration/run-relative mismatch");
@@ -2046,12 +2081,12 @@ mod tests {
     #[test]
     fn non_strict_duration_mismatching_run_relative_warns_and_retains_duration() {
         let spans = vec![SpanRecord::new("req", 10, 60)
-            .started_at_run_us(1_000)
-            .finished_at_run_us(11_000)
-            .duration_us(50_000)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_started_at_run_us(1_000)
+            .with_finished_at_run_us(11_000)
+            .with_duration_us(50_000)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
 
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
 
@@ -2072,11 +2107,11 @@ mod tests {
     #[test]
     fn non_strict_inverted_request_run_relative_offsets_are_dropped_with_warning() {
         let spans = vec![SpanRecord::new("req", 100, 120)
-            .started_at_run_us(20_000)
-            .finished_at_run_us(10_000)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_started_at_run_us(20_000)
+            .with_finished_at_run_us(10_000)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
 
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
 
@@ -2098,11 +2133,11 @@ mod tests {
     #[test]
     fn strict_inverted_request_run_relative_offsets_fail() {
         let spans = vec![SpanRecord::new("req", 100, 120)
-            .started_at_run_us(20_000)
-            .finished_at_run_us(10_000)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_started_at_run_us(20_000)
+            .with_finished_at_run_us(10_000)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
 
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
             .expect_err("strict import should reject inverted run-relative offsets");
@@ -2115,10 +2150,10 @@ mod tests {
     #[test]
     fn non_strict_incomplete_request_run_relative_offsets_are_dropped_with_warning() {
         let spans = vec![SpanRecord::new("req", 100, 120)
-            .started_at_run_us(10_000)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_started_at_run_us(10_000)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
 
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
 
@@ -2140,15 +2175,15 @@ mod tests {
     fn non_strict_inverted_queue_run_relative_offsets_are_dropped_with_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 102, 103)
-                .started_at_run_us(3_000)
-                .finished_at_run_us(2_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_started_at_run_us(3_000)
+                .with_finished_at_run_us(2_000)
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
 
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
@@ -2168,15 +2203,15 @@ mod tests {
     fn non_strict_inverted_stage_run_relative_without_duration_uses_coarse_delta() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("stage", 102, 105)
-                .started_at_run_us(5_000)
-                .finished_at_run_us(2_000)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_started_at_run_us(5_000)
+                .with_finished_at_run_us(2_000)
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
         ];
 
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
@@ -2200,15 +2235,15 @@ mod tests {
     fn strict_inverted_queue_run_relative_offsets_fail() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 102, 103)
-                .started_at_run_us(3_000)
-                .finished_at_run_us(2_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_started_at_run_us(3_000)
+                .with_finished_at_run_us(2_000)
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
 
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
@@ -2223,14 +2258,14 @@ mod tests {
     fn non_strict_incomplete_queue_run_relative_offsets_are_dropped_with_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 102, 103)
-                .finished_at_run_us(3_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_finished_at_run_us(3_000)
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
 
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
@@ -2253,14 +2288,14 @@ mod tests {
     fn strict_incomplete_queue_run_relative_offsets_fail() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 102, 103)
-                .finished_at_run_us(3_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_finished_at_run_us(3_000)
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
 
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
@@ -2275,13 +2310,13 @@ mod tests {
     fn non_strict_orphan_stage_is_skipped_and_warning_is_durable() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st", 102, 119)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r-orphan")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r-orphan")
+                .with_field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
@@ -2304,13 +2339,13 @@ mod tests {
     fn orphan_stage_does_not_affect_retained_bounds_or_default_stage_success_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st", 1, 1_000_000)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r-orphan")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r-orphan")
+                .with_field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         let run = imported.run();
@@ -2338,13 +2373,13 @@ mod tests {
     fn strict_orphan_stage_fails() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st", 102, 119)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r-orphan")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r-orphan")
+                .with_field(TT_STAGE, "db"),
         ];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         match err {
@@ -2360,13 +2395,13 @@ mod tests {
     fn non_strict_orphan_queue_is_skipped_and_warning_is_durable() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 102, 119)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r-orphan")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r-orphan")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
@@ -2389,13 +2424,13 @@ mod tests {
     fn strict_orphan_queue_fails() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 102, 119)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r-orphan")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r-orphan")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         match err {
@@ -2411,13 +2446,13 @@ mod tests {
     fn wall_clock_stage_before_request_start_is_retained_without_precise_containment_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("stage", 97, 110)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 1);
@@ -2441,13 +2476,13 @@ mod tests {
     fn wall_clock_stage_after_request_finish_is_retained_without_precise_containment_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("stage", 110, 123)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 1);
@@ -2471,13 +2506,13 @@ mod tests {
     fn wall_clock_queue_before_request_start_is_retained_without_precise_containment_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("queue", 97, 110)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().queues.len(), 1);
@@ -2501,13 +2536,13 @@ mod tests {
     fn wall_clock_queue_after_request_finish_is_retained_without_precise_containment_warning() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("queue", 110, 123)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().queues.len(), 1);
@@ -2531,17 +2566,17 @@ mod tests {
     fn precise_stage_outside_request_is_excluded_permissively_and_rejected_strictly() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .started_at_run_us(100_000)
-                .finished_at_run_us(120_000)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_started_at_run_us(100_000)
+                .with_finished_at_run_us(120_000)
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("stage", 97, 110)
-                .started_at_run_us(97_000)
-                .finished_at_run_us(110_000)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_started_at_run_us(97_000)
+                .with_finished_at_run_us(110_000)
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans.clone(), ImportOptions::new("svc")).unwrap();
         assert!(imported.run().stages.is_empty());
@@ -2559,17 +2594,17 @@ mod tests {
     fn precise_queue_outside_request_is_excluded_permissively_and_rejected_strictly() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .started_at_run_us(100_000)
-                .finished_at_run_us(120_000)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_started_at_run_us(100_000)
+                .with_finished_at_run_us(120_000)
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("queue", 110, 123)
-                .started_at_run_us(110_000)
-                .finished_at_run_us(123_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_started_at_run_us(110_000)
+                .with_finished_at_run_us(123_000)
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans.clone(), ImportOptions::new("svc")).unwrap();
         assert!(imported.run().queues.is_empty());
@@ -2587,13 +2622,13 @@ mod tests {
     fn wall_clock_stage_starting_before_request_is_retained_without_containment() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("stage", 99, 110)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 1);
@@ -2604,13 +2639,13 @@ mod tests {
     fn wall_clock_queue_ending_after_request_is_retained_without_containment() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("queue", 110, 121)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().queues.len(), 1);
@@ -2621,17 +2656,17 @@ mod tests {
     fn boundary_equal_stage_and_queue_are_accepted() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("stage", 100, 120)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("queue", 100, 120)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -2646,17 +2681,17 @@ mod tests {
     fn zero_duration_request_with_boundary_equal_stage_and_queue_is_accepted() {
         let spans = vec![
             SpanRecord::new("req", 100, 100)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("stage", 100, 100)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("queue", 100, 100)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -2673,18 +2708,18 @@ mod tests {
     fn non_strict_duplicate_request_id_excludes_all_duplicate_requests_and_children() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "dup")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "dup")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("req-2", 200, 260)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "dup")
-                .field(TT_ROUTE, "/b")
-                .field(TT_OUTCOME, "error"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "dup")
+                .with_field(TT_ROUTE, "/b")
+                .with_field(TT_OUTCOME, "error"),
             SpanRecord::new("stage-skipped", 210, 220)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "dup")
-                .field(TT_STAGE, "downstream"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "dup")
+                .with_field(TT_STAGE, "downstream"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         let run = imported.run();
@@ -2723,14 +2758,14 @@ mod tests {
     fn non_strict_retained_duplicate_missing_outcome_warns_before_core_exclusion() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "dup")
-                .field(TT_ROUTE, "/a")
-                .field(TT_OUTCOME, "ok"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "dup")
+                .with_field(TT_ROUTE, "/a")
+                .with_field(TT_OUTCOME, "ok"),
             SpanRecord::new("req-2", 200, 260)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "dup")
-                .field(TT_ROUTE, "/b"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "dup")
+                .with_field(TT_ROUTE, "/b"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         let run = imported.run();
@@ -2754,13 +2789,13 @@ mod tests {
     fn strict_duplicate_request_id_fails() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "dup")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "dup")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("req-2", 101, 121)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "dup")
-                .field(TT_ROUTE, "/b"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "dup")
+                .with_field(TT_ROUTE, "/b"),
         ];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
@@ -2771,17 +2806,17 @@ mod tests {
     fn strict_error_lists_unique_core_issue_codes_once_in_order() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "dup")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "dup")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("req-2", 130, 150)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "dup")
-                .field(TT_ROUTE, "/b"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "dup")
+                .with_field(TT_ROUTE, "/b"),
             SpanRecord::new("stage", 135, 140)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "dup")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "dup")
+                .with_field(TT_STAGE, "db"),
         ];
 
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
@@ -2803,17 +2838,17 @@ mod tests {
     fn overflow_duplicate_request_ids_beyond_max_requests_do_not_warn() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("req-2", 101, 121)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_ROUTE, "/b"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_ROUTE, "/b"),
             SpanRecord::new("req-overflow", 102, 122)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/overflow"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/overflow"),
         ];
         let imported = run_from_span_records(
             spans,
@@ -2836,23 +2871,23 @@ mod tests {
     fn invalid_extreme_timestamps_do_not_affect_metadata_bounds_or_default_run_id() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .started_at_run_us(100_000)
-                .finished_at_run_us(120_000)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_started_at_run_us(100_000)
+                .with_finished_at_run_us(120_000)
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("stage-extreme", 1, 1_000_000)
-                .started_at_run_us(1_000)
-                .finished_at_run_us(1_000_000_000)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_started_at_run_us(1_000)
+                .with_finished_at_run_us(1_000_000_000)
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("queue-extreme", 1, 1_000_000)
-                .started_at_run_us(1_000)
-                .finished_at_run_us(1_000_000_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_started_at_run_us(1_000)
+                .with_finished_at_run_us(1_000_000_000)
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         let run = imported.run();
@@ -2868,15 +2903,15 @@ mod tests {
     fn orphan_queue_does_not_affect_retained_bounds_or_default_run_id() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .started_at_run_us(100_000)
-                .finished_at_run_us(120_000)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_started_at_run_us(100_000)
+                .with_finished_at_run_us(120_000)
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 1, 1_000_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r-orphan")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r-orphan")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         let run = imported.run();
@@ -2895,17 +2930,17 @@ mod tests {
         for index in 0..max_requests {
             spans.push(
                 SpanRecord::new(format!("req-{index}"), 100, 120)
-                    .field(TT_KIND, "request")
-                    .field(TT_REQUEST_ID, format!("r{index}"))
-                    .field(TT_ROUTE, "/a")
-                    .field(TT_OUTCOME, "ok"),
+                    .with_field(TT_KIND, "request")
+                    .with_field(TT_REQUEST_ID, format!("r{index}"))
+                    .with_field(TT_ROUTE, "/a")
+                    .with_field(TT_OUTCOME, "ok"),
             );
         }
         spans.push(
             SpanRecord::new("overflow", 1, 1_000_000)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r-overflow")
-                .field(TT_ROUTE, "/overflow"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r-overflow")
+                .with_field(TT_ROUTE, "/overflow"),
         );
         let imported = run_from_span_records(
             spans,
@@ -2933,24 +2968,24 @@ mod tests {
     fn overflow_stage_does_not_affect_metadata_bounds_or_success_warning() {
         let max_stages = 2;
         let mut spans = vec![SpanRecord::new("req", 100, 120)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")
-            .field(TT_OUTCOME, "ok")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")
+            .with_field(TT_OUTCOME, "ok")];
         for index in 0..max_stages {
             spans.push(
                 SpanRecord::new(format!("stage-{index}"), 101, 110)
-                    .field(TT_KIND, "stage")
-                    .field(TT_REQUEST_ID, "r1")
-                    .field(TT_STAGE, format!("s{index}"))
-                    .field(TT_SUCCESS, true),
+                    .with_field(TT_KIND, "stage")
+                    .with_field(TT_REQUEST_ID, "r1")
+                    .with_field(TT_STAGE, format!("s{index}"))
+                    .with_field(TT_SUCCESS, true),
             );
         }
         spans.push(
             SpanRecord::new("overflow-stage", 1, 1_000_000)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "overflow-stage"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "overflow-stage"),
         );
         let imported = run_from_span_records(
             spans,
@@ -2977,23 +3012,23 @@ mod tests {
     fn overflow_queue_does_not_affect_metadata_bounds() {
         let max_queues = 2;
         let mut spans = vec![SpanRecord::new("req", 100, 120)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")
-            .field(TT_OUTCOME, "ok")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")
+            .with_field(TT_OUTCOME, "ok")];
         for index in 0..max_queues {
             spans.push(
                 SpanRecord::new(format!("queue-{index}"), 101, 110)
-                    .field(TT_KIND, "queue")
-                    .field(TT_REQUEST_ID, "r1")
-                    .field(TT_QUEUE, format!("q{index}")),
+                    .with_field(TT_KIND, "queue")
+                    .with_field(TT_REQUEST_ID, "r1")
+                    .with_field(TT_QUEUE, format!("q{index}")),
             );
         }
         spans.push(
             SpanRecord::new("overflow-queue", 1, 1_000_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "overflow-queue"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "overflow-queue"),
         );
         let imported = run_from_span_records(
             spans,
@@ -3017,29 +3052,29 @@ mod tests {
     fn run_from_span_records_respects_import_mode_and_resolved_limits() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("req-2", 101, 121)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_ROUTE, "/b"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_ROUTE, "/b"),
             SpanRecord::new("stage-1", 102, 110)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "s1"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "s1"),
             SpanRecord::new("stage-2", 103, 111)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "s2"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "s2"),
             SpanRecord::new("queue-1", 104, 112)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "q1"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "q1"),
             SpanRecord::new("queue-2", 105, 113)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "q2"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "q2"),
         ];
         let limits = tailtriage_core::CaptureLimitsOverride {
             max_requests: Some(1),
@@ -3077,9 +3112,9 @@ mod tests {
     #[test]
     fn retained_request_missing_outcome_still_warns() {
         let spans = vec![SpanRecord::new("req", 100, 120)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.warnings().iter().any(|w| w
             .message()
@@ -3091,14 +3126,14 @@ mod tests {
     fn retained_stage_missing_success_still_warns() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a")
-                .field(TT_OUTCOME, "ok"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a")
+                .with_field(TT_OUTCOME, "ok"),
             SpanRecord::new("stage", 105, 115)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.warnings().iter().any(|w| w
@@ -3111,17 +3146,17 @@ mod tests {
     fn matched_request_stage_queue_are_retained() {
         let spans = vec![
             SpanRecord::new("req", 100, 120)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st", 105, 115)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("q", 102, 103)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -3137,17 +3172,17 @@ mod tests {
     fn missing_optional_fields_default() {
         let spans = vec![
             SpanRecord::new("req", 1, 2)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/"),
             SpanRecord::new("st", 1, 2)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "s1"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "s1"),
             SpanRecord::new("q", 1, 2)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "q1"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "q1"),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -3162,8 +3197,8 @@ mod tests {
     #[test]
     fn missing_required_field_warns_and_skips_non_strict() {
         let spans = vec![SpanRecord::new("req", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 0);
         assert!(!imported.warnings().is_empty());
@@ -3173,8 +3208,8 @@ mod tests {
     #[test]
     fn missing_required_field_errors_in_strict() {
         let spans = vec![SpanRecord::new("req", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
@@ -3182,7 +3217,7 @@ mod tests {
     // TT-TEST: R02 primary
     #[test]
     fn unknown_kind_warns_non_strict() {
-        let spans = vec![SpanRecord::new("x", 1, 2).field(TT_KIND, "wat")];
+        let spans = vec![SpanRecord::new("x", 1, 2).with_field(TT_KIND, "wat")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(!imported.warnings().is_empty());
         assert!(imported
@@ -3196,7 +3231,7 @@ mod tests {
     // TT-TEST: R02 primary
     #[test]
     fn unknown_kind_errors_in_strict() {
-        let spans = vec![SpanRecord::new("x", 1, 2).field(TT_KIND, "wat")];
+        let spans = vec![SpanRecord::new("x", 1, 2).with_field(TT_KIND, "wat")];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
     }
@@ -3204,7 +3239,7 @@ mod tests {
     // TT-TEST: support
     #[test]
     fn span_without_kind_ignored_silently() {
-        let spans = vec![SpanRecord::new("x", 1, 2).field("a", "b")];
+        let spans = vec![SpanRecord::new("x", 1, 2).with_field("a", "b")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.warnings().is_empty());
     }
@@ -3213,8 +3248,8 @@ mod tests {
     #[test]
     fn tailtriage_tagged_span_missing_kind_warns_or_errors() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
         let imported = run_from_span_records(spans.clone(), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 0);
         assert!(imported.warnings().iter().any(|w| w
@@ -3230,25 +3265,25 @@ mod tests {
     fn missing_optional_defaults_emit_aggregate_warnings() {
         let spans = vec![
             SpanRecord::new("req1", 1, 2)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("req2", 1, 2)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_ROUTE, "/b"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_ROUTE, "/b"),
             SpanRecord::new("st1", 1, 2)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("st2", 1, 2)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_STAGE, "cache"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_STAGE, "cache"),
             SpanRecord::new("q", 1, 2)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         let msgs = imported
@@ -3290,9 +3325,9 @@ mod tests {
     #[test]
     fn inverted_timestamps_warn_or_error() {
         let spans = vec![SpanRecord::new("req", 5, 4)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")];
         let imported = run_from_span_records(spans.clone(), ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 0);
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
@@ -3302,7 +3337,7 @@ mod tests {
     // TT-TEST: support
     #[test]
     fn run_from_span_records_validates_service_name_before_strict_span_parsing() {
-        let spans = vec![SpanRecord::new("bad", 10, 20).field(TT_KIND, 123_u64)];
+        let spans = vec![SpanRecord::new("bad", 10, 20).with_field(TT_KIND, 123_u64)];
         let err = run_from_span_records(spans, ImportOptions::new("   ").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::EmptyServiceName));
     }
@@ -3331,13 +3366,13 @@ mod tests {
         let imported = run_from_span_records(
             vec![
                 SpanRecord::new("req-a", 10, 20)
-                    .field(TT_KIND, "request")
-                    .field(TT_REQUEST_ID, "dup")
-                    .field(TT_ROUTE, "/a"),
+                    .with_field(TT_KIND, "request")
+                    .with_field(TT_REQUEST_ID, "dup")
+                    .with_field(TT_ROUTE, "/a"),
                 SpanRecord::new("req-b", 30, 40)
-                    .field(TT_KIND, "request")
-                    .field(TT_REQUEST_ID, "dup")
-                    .field(TT_ROUTE, "/b"),
+                    .with_field(TT_KIND, "request")
+                    .with_field(TT_REQUEST_ID, "dup")
+                    .with_field(TT_ROUTE, "/b"),
             ],
             ImportOptions::new("svc"),
         )
@@ -3421,9 +3456,9 @@ mod tests {
     #[test]
     fn tracing_import_uses_min_start_and_max_finish_as_run_bounds() {
         let spans = vec![SpanRecord::new("req", 10, 20)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
             .run()
@@ -3437,9 +3472,9 @@ mod tests {
     #[test]
     fn run_from_span_records_preserves_computed_import_run_id() {
         let spans = vec![SpanRecord::new("req", 10, 20)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
             .run()
@@ -3451,9 +3486,9 @@ mod tests {
     #[test]
     fn run_from_span_records_preserves_explicit_import_run_id() {
         let spans = vec![SpanRecord::new("req", 10, 20)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")];
         let run = run_from_span_records(spans, ImportOptions::new("svc").run_id("explicit-run"))
             .unwrap()
             .run()
@@ -3473,11 +3508,11 @@ mod tests {
     #[test]
     fn ordinary_span_without_kind_does_not_affect_metadata_bounds() {
         let spans = vec![
-            SpanRecord::new("ordinary", 1, 1_000).field("foo", "bar"),
+            SpanRecord::new("ordinary", 1, 1_000).with_field("foo", "bar"),
             SpanRecord::new("req", 10, 20)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/"),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -3491,11 +3526,11 @@ mod tests {
     #[test]
     fn unknown_kind_does_not_affect_metadata_bounds_and_is_durable_lifecycle_warning() {
         let spans = vec![
-            SpanRecord::new("unknown", 1, 1_000).field(TT_KIND, "wat"),
+            SpanRecord::new("unknown", 1, 1_000).with_field(TT_KIND, "wat"),
             SpanRecord::new("req", 10, 20)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().metadata.started_at_unix_ms, 10);
@@ -3518,7 +3553,7 @@ mod tests {
     // TT-TEST: support
     #[test]
     fn non_string_kind_warns_non_strict_and_errors_strict() {
-        let bad = SpanRecord::new("bad", 1, 2).field(TT_KIND, true);
+        let bad = SpanRecord::new("bad", 1, 2).with_field(TT_KIND, true);
         let imported = run_from_span_records(vec![bad.clone()], ImportOptions::new("svc")).unwrap();
         assert!(!imported.warnings().is_empty());
         assert!(run_from_span_records(vec![bad], ImportOptions::new("svc").strict(true)).is_err());
@@ -3528,9 +3563,9 @@ mod tests {
     #[test]
     fn non_string_required_and_optional_fields_warn_non_strict_and_error_strict() {
         let bad_route = SpanRecord::new("req", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, true);
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, true);
         let imported =
             run_from_span_records(vec![bad_route.clone()], ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
@@ -3540,10 +3575,10 @@ mod tests {
         );
 
         let bad_outcome = SpanRecord::new("req", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, 7_u64);
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")
+            .with_field(TT_OUTCOME, 7_u64);
         let imported =
             run_from_span_records(vec![bad_outcome.clone()], ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
@@ -3558,9 +3593,9 @@ mod tests {
     #[test]
     fn whitespace_only_request_id_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("req", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "   ")
-            .field(TT_ROUTE, "/")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "   ")
+            .with_field(TT_ROUTE, "/")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.warnings().iter().any(|w| {
@@ -3574,9 +3609,9 @@ mod tests {
     #[test]
     fn whitespace_only_route_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("req", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "  \t")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "  \t")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.warnings().iter().any(|w| {
@@ -3591,13 +3626,13 @@ mod tests {
     fn whitespace_only_stage_non_strict_skips_stage_and_warns() {
         let spans = vec![
             SpanRecord::new("req", 1, 3)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/"),
             SpanRecord::new("stage", 1, 2)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "   "),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "   "),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().stages.is_empty());
@@ -3613,13 +3648,13 @@ mod tests {
     fn whitespace_only_queue_non_strict_skips_queue_and_warns() {
         let spans = vec![
             SpanRecord::new("req", 1, 3)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/"),
             SpanRecord::new("queue", 1, 2)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, " "),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, " "),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().queues.is_empty());
@@ -3634,9 +3669,9 @@ mod tests {
     #[test]
     fn whitespace_only_required_field_strict_returns_strict_violation() {
         let spans = vec![SpanRecord::new("req", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, " ")
-            .field(TT_ROUTE, "/")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, " ")
+            .with_field(TT_ROUTE, "/")];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
         assert!(err
@@ -3652,10 +3687,10 @@ mod tests {
             .enumerate()
             .map(|(idx, outcome)| {
                 SpanRecord::new("req", idx as u64 + 1, idx as u64 + 2)
-                    .field(TT_KIND, "request")
-                    .field(TT_REQUEST_ID, format!("r{idx}"))
-                    .field(TT_ROUTE, "/")
-                    .field(TT_OUTCOME, *outcome)
+                    .with_field(TT_KIND, "request")
+                    .with_field(TT_REQUEST_ID, format!("r{idx}"))
+                    .with_field(TT_ROUTE, "/")
+                    .with_field(TT_OUTCOME, *outcome)
             })
             .collect::<Vec<_>>();
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
@@ -3672,9 +3707,9 @@ mod tests {
     #[test]
     fn missing_outcome_defaults_ok_and_warns() {
         let spans = vec![SpanRecord::new("req", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].outcome, "ok");
@@ -3687,10 +3722,10 @@ mod tests {
     #[test]
     fn custom_outcome_is_accepted_and_preserved_exactly() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "cache_miss_fallback")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")
+            .with_field(TT_OUTCOME, "cache_miss_fallback")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].outcome, "cache_miss_fallback");
@@ -3700,10 +3735,10 @@ mod tests {
     #[test]
     fn whitespace_only_outcome_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, "   ")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")
+            .with_field(TT_OUTCOME, "   ")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.warnings().iter().any(|w| w
@@ -3715,10 +3750,10 @@ mod tests {
     #[test]
     fn whitespace_only_outcome_strict_fails() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, " \t")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")
+            .with_field(TT_OUTCOME, " \t")];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
         assert!(err
@@ -3730,10 +3765,10 @@ mod tests {
     #[test]
     fn non_string_outcome_non_strict_skips_request_and_warns() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, 42_u64)];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")
+            .with_field(TT_OUTCOME, 42_u64)];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
         assert!(imported.warnings().iter().any(|w| w
@@ -3745,10 +3780,10 @@ mod tests {
     #[test]
     fn non_string_outcome_strict_fails() {
         let spans = vec![SpanRecord::new("http.request", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, false)];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")
+            .with_field(TT_OUTCOME, false)];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true)).unwrap_err();
         assert!(matches!(err, ImportError::StrictViolation(_)));
         assert!(err
@@ -3761,10 +3796,10 @@ mod tests {
     fn native_other_outcome_round_trips_through_tracing_style_outcome_field() {
         let native = tailtriage_core::Outcome::Other("custom".to_owned());
         let spans = vec![SpanRecord::new("http.request", 1, 2)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/")
-            .field(TT_OUTCOME, native.as_str())];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/")
+            .with_field(TT_OUTCOME, native.as_str())];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests.len(), 1);
         assert_eq!(imported.run().requests[0].outcome, native.as_str());
@@ -3775,19 +3810,19 @@ mod tests {
     fn invalid_whitespace_outcome_skips_child_spans_via_existing_correlation_logic() {
         let spans = vec![
             SpanRecord::new("http.request", 1_000, 2_000)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/")
-                .field(TT_OUTCOME, "   "),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/")
+                .with_field(TT_OUTCOME, "   "),
             SpanRecord::new("db.stage", 1_100, 1_200)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db")
-                .field(TT_SUCCESS, true),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db")
+                .with_field(TT_SUCCESS, true),
             SpanRecord::new("worker.queue", 1_300, 1_350)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "worker"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "worker"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert!(imported.run().requests.is_empty());
@@ -3801,24 +3836,24 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_duplicate_request_id_overflow_keeps_retained_children() {
+    fn strict_duplicate_request_id_overflow_keeps_retained_children() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 200)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st-1", 120, 150)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("q-1", 130, 140)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
             SpanRecord::new("req-2", 300, 400)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
         ];
         let imported = run_from_span_records(
             spans,
@@ -3852,24 +3887,24 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_duplicate_request_id_overflow_only_children_retains_coarse_timing() {
+    fn strict_duplicate_request_id_overflow_only_children_retains_coarse_timing() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 200)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("req-2", 300, 400)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st-1", 320, 350)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("q-1", 330, 340)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(
             spans,
@@ -3892,21 +3927,21 @@ mod tests {
     fn non_strict_duplicate_request_id_overflow_only_children_retains_coarse_timing() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 200)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("req-2", 300, 400)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st-1", 320, 350)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("q-1", 330, 340)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(
             spans,
@@ -3950,32 +3985,32 @@ mod tests {
     }
     // TT-TEST: support
     #[test]
-    fn strict_mode_max_requests_overflow_children_are_retention_fallout() {
+    fn strict_max_requests_overflow_children_are_retention_fallout() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 200)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st-1", 120, 150)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("q-1", 121, 130)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
             SpanRecord::new("req-2", 300, 400)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st-2", 320, 350)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("q-2", 321, 330)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(
             spans,
@@ -3995,20 +4030,20 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_max_requests_overflow_invalid_stage_still_fails() {
+    fn strict_max_requests_overflow_invalid_stage_still_fails() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 200)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("req-2", 300, 400)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st-2", 320, 450)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_STAGE, "db"),
         ];
         let err = run_from_span_records(
             spans,
@@ -4030,20 +4065,20 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_max_requests_overflow_invalid_queue_still_fails() {
+    fn strict_max_requests_overflow_invalid_queue_still_fails() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 200)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("req-2", 300, 400)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q-2", 320, 450)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r2")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r2")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let err = run_from_span_records(
             spans,
@@ -4065,32 +4100,32 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_max_requests_overflow_non_lexical_request_ids_follow_input_order() {
+    fn strict_max_requests_overflow_non_lexical_request_ids_follow_input_order() {
         let spans = vec![
             SpanRecord::new("req-1", 100, 200)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "z-retained")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "z-retained")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st-1", 120, 150)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "z-retained")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "z-retained")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("q-1", 121, 130)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "z-retained")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "z-retained")
+                .with_field(TT_QUEUE, "permits"),
             SpanRecord::new("req-2", 300, 400)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "a-overflow")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "a-overflow")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("st-2", 320, 350)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "a-overflow")
-                .field(TT_STAGE, "db"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "a-overflow")
+                .with_field(TT_STAGE, "db"),
             SpanRecord::new("q-2", 321, 330)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "a-overflow")
-                .field(TT_QUEUE, "permits"),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "a-overflow")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(
             spans,
@@ -4113,15 +4148,15 @@ mod tests {
     fn invalid_success_warns_and_skips_stage_non_strict() {
         let spans = vec![
             SpanRecord::new("req", 10, 20)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/")
-                .field(TT_OUTCOME, "ok"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/")
+                .with_field(TT_OUTCOME, "ok"),
             SpanRecord::new("st", 1, 1_000)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db")
-                .field(TT_SUCCESS, 7_u64),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db")
+                .with_field(TT_SUCCESS, 7_u64),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages.len(), 0);
@@ -4142,15 +4177,15 @@ mod tests {
     fn invalid_success_errors_strict() {
         let spans = vec![
             SpanRecord::new("req", 10, 20)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/")
-                .field(TT_OUTCOME, "ok"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/")
+                .with_field(TT_OUTCOME, "ok"),
             SpanRecord::new("st", 1, 1_000)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db")
-                .field(TT_SUCCESS, 7_u64),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db")
+                .with_field(TT_SUCCESS, 7_u64),
         ];
         assert!(run_from_span_records(spans, ImportOptions::new("svc").strict(true)).is_err());
     }
@@ -4160,15 +4195,15 @@ mod tests {
     fn invalid_depth_warns_and_skips_queue_non_strict() {
         let spans = vec![
             SpanRecord::new("req", 10, 20)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/")
-                .field(TT_OUTCOME, "ok"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/")
+                .with_field(TT_OUTCOME, "ok"),
             SpanRecord::new("q", 1, 1_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits")
-                .field(TT_DEPTH_AT_START, -1_i64),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits")
+                .with_field(TT_DEPTH_AT_START, -1_i64),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().queues.len(), 0);
@@ -4189,15 +4224,15 @@ mod tests {
     fn invalid_depth_errors_strict() {
         let spans = vec![
             SpanRecord::new("req", 10, 20)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/")
-                .field(TT_OUTCOME, "ok"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/")
+                .with_field(TT_OUTCOME, "ok"),
             SpanRecord::new("q", 1, 1_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits")
-                .field(TT_DEPTH_AT_START, 3.5_f64),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits")
+                .with_field(TT_DEPTH_AT_START, 3.5_f64),
         ];
         assert!(run_from_span_records(spans, ImportOptions::new("svc").strict(true)).is_err());
     }
@@ -4207,19 +4242,19 @@ mod tests {
     fn valid_optional_fields_are_applied() {
         let spans = vec![
             SpanRecord::new("req", 1, 2)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/"),
             SpanRecord::new("st", 1, 2)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db")
-                .field(TT_SUCCESS, "false"),
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db")
+                .with_field(TT_SUCCESS, "false"),
             SpanRecord::new("q", 1, 2)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits")
-                .field(TT_DEPTH_AT_START, 9_i64),
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits")
+                .with_field(TT_DEPTH_AT_START, 9_i64),
         ];
         let run = run_from_span_records(spans, ImportOptions::new("svc"))
             .unwrap()
@@ -4231,14 +4266,14 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn mismatched_request_duration_warns_and_retains_duration_us_in_non_strict_mode() {
+    fn mismatched_request_duration_warns_and_retains_duration_us_in_non_strict() {
         let spans = vec![SpanRecord::new("req", 100, 101)
-            .started_at_run_us(100_000)
-            .finished_at_run_us(101_000)
-            .duration_us(50_000)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_started_at_run_us(100_000)
+            .with_finished_at_run_us(101_000)
+            .with_duration_us(50_000)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests[0].latency_us, 50_000);
         assert!(imported
@@ -4261,10 +4296,10 @@ mod tests {
     #[test]
     fn absent_request_duration_us_derives_from_timestamps() {
         let spans = vec![SpanRecord::new("req", 100, 101)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")
-            .field(TT_OUTCOME, "ok")];
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")
+            .with_field(TT_OUTCOME, "ok")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests[0].latency_us, 1_000);
         assert!(imported.warnings().iter().any(|w| w
@@ -4280,19 +4315,19 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn mismatched_stage_duration_warns_and_retains_duration_us_in_non_strict_mode() {
+    fn mismatched_stage_duration_warns_and_retains_duration_us_in_non_strict() {
         let spans = vec![
             SpanRecord::new("req", 99, 101)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/"),
             SpanRecord::new("stage", 100, 101)
-                .started_at_run_us(100_000)
-                .finished_at_run_us(101_000)
-                .duration_us(50_000)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_started_at_run_us(100_000)
+                .with_finished_at_run_us(101_000)
+                .with_duration_us(50_000)
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().stages[0].latency_us, 50_000);
@@ -4304,19 +4339,19 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn mismatched_queue_duration_warns_and_retains_duration_us_in_non_strict_mode() {
+    fn mismatched_queue_duration_warns_and_retains_duration_us_in_non_strict() {
         let spans = vec![
             SpanRecord::new("req", 100, 110)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 101, 102)
-                .started_at_run_us(101_000)
-                .finished_at_run_us(102_000)
-                .duration_us(50_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_started_at_run_us(101_000)
+                .with_finished_at_run_us(102_000)
+                .with_duration_us(50_000)
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().queues[0].wait_us, 50_000);
@@ -4328,14 +4363,14 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_rejects_mismatched_request_duration() {
+    fn strict_rejects_mismatched_request_duration() {
         let spans = vec![SpanRecord::new("req", 100, 101)
-            .started_at_run_us(100_000)
-            .finished_at_run_us(101_000)
-            .duration_us(50_000)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_started_at_run_us(100_000)
+            .with_finished_at_run_us(101_000)
+            .with_duration_us(50_000)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
         let err = run_from_span_records(spans, ImportOptions::new("svc").strict(true))
             .expect_err("strict import should reject mismatched duration_us");
         assert!(matches!(err, ImportError::StrictViolation(_)));
@@ -4345,19 +4380,19 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_rejects_contradictory_stage_duration() {
+    fn strict_rejects_contradictory_stage_duration() {
         let spans = vec![
             SpanRecord::new("req", 99, 101)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/"),
             SpanRecord::new("stage", 100, 101)
-                .started_at_run_us(100_000)
-                .finished_at_run_us(101_000)
-                .duration_us(50_000)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_STAGE, "db"),
+                .with_started_at_run_us(100_000)
+                .with_finished_at_run_us(101_000)
+                .with_duration_us(50_000)
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_STAGE, "db"),
         ];
         assert!(matches!(
             run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
@@ -4367,19 +4402,19 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_rejects_contradictory_queue_duration() {
+    fn strict_rejects_contradictory_queue_duration() {
         let spans = vec![
             SpanRecord::new("req", 100, 110)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_ROUTE, "/a"),
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_ROUTE, "/a"),
             SpanRecord::new("q", 101, 102)
-                .started_at_run_us(101_000)
-                .finished_at_run_us(102_000)
-                .duration_us(50_000)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, "r1")
-                .field(TT_QUEUE, "permits"),
+                .with_started_at_run_us(101_000)
+                .with_finished_at_run_us(102_000)
+                .with_duration_us(50_000)
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, "r1")
+                .with_field(TT_QUEUE, "permits"),
         ];
         assert!(matches!(
             run_from_span_records(spans, ImportOptions::new("svc").strict(true)),
@@ -4391,10 +4426,10 @@ mod tests {
     #[test]
     fn duration_us_within_2000_microseconds_is_accepted() {
         let spans = vec![SpanRecord::new("req", 100, 101)
-            .duration_us(2_999)
-            .field(TT_KIND, "request")
-            .field(TT_REQUEST_ID, "r1")
-            .field(TT_ROUTE, "/a")];
+            .with_duration_us(2_999)
+            .with_field(TT_KIND, "request")
+            .with_field(TT_REQUEST_ID, "r1")
+            .with_field(TT_ROUTE, "/a")];
         let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();
         assert_eq!(imported.run().requests[0].latency_us, 2_999);
         assert!(!imported

--- a/tailtriage-tracing/src/recorder.rs
+++ b/tailtriage-tracing/src/recorder.rs
@@ -847,7 +847,7 @@ impl LiveRecorderBuilder {
     #[cfg(feature = "tokio")]
     #[must_use]
     pub(crate) fn capture_mode(&self) -> CaptureMode {
-        self.options.mode_value()
+        self.options.capture_mode()
     }
 
     /// Returns capture limits resolved from configured mode/base/override settings.
@@ -1004,17 +1004,17 @@ where
             }
             let duration_us = duration_us_between(open.started_instant, closed_instant);
             let mut record = SpanRecord::new(open.name, open.started_at_unix_ms, closed_at_unix_ms)
-                .started_at_run_us(open.started_at_run_us)
-                .finished_at_run_us(finished_at_run_us)
-                .duration_us(duration_us);
+                .with_started_at_run_us(open.started_at_run_us)
+                .with_finished_at_run_us(finished_at_run_us)
+                .with_duration_us(duration_us);
             if let Some(span_id) = open.id {
-                record = record.id(span_id);
+                record = record.with_id(span_id);
             }
             if let Some(parent_id) = open.parent_id {
-                record = record.parent_id(parent_id);
+                record = record.with_parent_id(parent_id);
             }
             for (k, v) in open.fields {
-                record = record.field(k, v);
+                record = record.with_field(k, v);
             }
             push_completed_candidate_with_kind_aware_retention(
                 &mut state,
@@ -1451,7 +1451,7 @@ fn imported_with_drop_warnings(
     limits: RecorderLimits,
 ) -> Result<ImportedRun, ImportError> {
     let mut strict_messages = Vec::new();
-    if options.strict_mode() {
+    if options.is_strict() {
         push_strict_recorder_messages(&mut strict_messages, stats, limits);
     }
 
@@ -1585,7 +1585,7 @@ mod tests {
             .map(|span| {
                 (
                     span.name().to_owned(),
-                    span.id_ref().unwrap_or_default().to_owned(),
+                    span.id().unwrap_or_default().to_owned(),
                 )
             })
             .collect()
@@ -1701,14 +1701,14 @@ mod tests {
             .iter()
             .map(|span| SourceIdentity {
                 name: span.name().to_owned(),
-                id: span.id_ref().map(ToOwned::to_owned),
-                parent_id: span.parent_id_ref().map(ToOwned::to_owned),
+                id: span.id().map(ToOwned::to_owned),
+                parent_id: span.parent_id().map(ToOwned::to_owned),
                 fields: span.fields().clone(),
                 started_at_unix_ms: span.started_at_unix_ms(),
                 finished_at_unix_ms: span.finished_at_unix_ms(),
-                started_at_run_us: span.started_at_run_us_ref(),
-                finished_at_run_us: span.finished_at_run_us_ref(),
-                duration_us: span.duration_us_ref(),
+                started_at_run_us: span.started_at_run_us(),
+                finished_at_run_us: span.finished_at_run_us(),
+                duration_us: span.duration_us(),
             })
             .collect()
     }
@@ -2108,7 +2108,7 @@ mod tests {
 
     // TT-TEST: R03 primary
     #[test]
-    fn strict_mode_errors_on_malformed_request() {
+    fn strict_errors_on_malformed_request() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -2493,7 +2493,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_errors_when_completed_candidate_cap_drops_spans() {
+    fn strict_errors_when_completed_candidate_cap_drops_spans() {
         let recorder = LiveRecorder::builder("svc")
             .strict(true)
             .max_completed_candidate_spans(1)
@@ -2527,7 +2527,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_errors_when_completed_candidate_cap_evicts_child_for_request() {
+    fn strict_errors_when_completed_candidate_cap_evicts_child_for_request() {
         let recorder = LiveRecorder::builder("svc")
             .strict(true)
             .max_completed_candidate_spans(2)
@@ -2734,7 +2734,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_errors_when_raw_cap_evicts_child_before_core_excludes_ambiguous_requests() {
+    fn strict_errors_when_raw_cap_evicts_child_before_core_excludes_ambiguous_requests() {
         let recorder = LiveRecorder::builder("svc")
             .strict(true)
             .max_completed_candidate_spans(3)
@@ -2843,30 +2843,30 @@ mod tests {
             let mut state = recorder.state.lock().unwrap();
             state.completed_stages.push(
                 SpanRecord::new("stage-a", 110, 120)
-                    .id("stage-id")
-                    .parent_id("req-id")
-                    .field(TT_KIND, "stage")
-                    .field("tt.request_id", "r1")
-                    .field("tt.stage", "db")
-                    .field("custom", "stage-custom"),
+                    .with_id("stage-id")
+                    .with_parent_id("req-id")
+                    .with_field(TT_KIND, "stage")
+                    .with_field("tt.request_id", "r1")
+                    .with_field("tt.stage", "db")
+                    .with_field("custom", "stage-custom"),
             );
             state.completed_queues.push(
                 SpanRecord::new("queue-a", 105, 109)
-                    .id("queue-id")
-                    .parent_id("req-id")
-                    .field(TT_KIND, "queue")
-                    .field("tt.request_id", "r1")
-                    .field("tt.queue", "permits")
-                    .field("custom", "queue-custom"),
+                    .with_id("queue-id")
+                    .with_parent_id("req-id")
+                    .with_field(TT_KIND, "queue")
+                    .with_field("tt.request_id", "r1")
+                    .with_field("tt.queue", "permits")
+                    .with_field("custom", "queue-custom"),
             );
             state.completed_requests.push(
                 SpanRecord::new("request-a", 100, 130)
-                    .id("req-id")
-                    .parent_id("root-id")
-                    .field(TT_KIND, "request")
-                    .field("tt.request_id", "r1")
-                    .field("tt.route", "/a")
-                    .field("custom", "request-custom"),
+                    .with_id("req-id")
+                    .with_parent_id("root-id")
+                    .with_field(TT_KIND, "request")
+                    .with_field("tt.request_id", "r1")
+                    .with_field("tt.route", "/a")
+                    .with_field("custom", "request-custom"),
             );
         }
 
@@ -2876,8 +2876,8 @@ mod tests {
             retained.iter().map(SpanRecord::name).collect::<Vec<_>>(),
             vec!["request-a", "stage-a", "queue-a"]
         );
-        assert_eq!(retained[0].id_ref(), Some("req-id"));
-        assert_eq!(retained[0].parent_id_ref(), Some("root-id"));
+        assert_eq!(retained[0].id(), Some("req-id"));
+        assert_eq!(retained[0].parent_id(), Some("root-id"));
         assert_eq!(
             retained[0].fields().get("custom"),
             Some(&FieldValue::String("request-custom".to_owned()))
@@ -2886,8 +2886,8 @@ mod tests {
             retained[0].fields().get(TT_KIND),
             Some(&FieldValue::String("request".to_owned()))
         );
-        assert_eq!(retained[1].id_ref(), Some("stage-id"));
-        assert_eq!(retained[1].parent_id_ref(), Some("req-id"));
+        assert_eq!(retained[1].id(), Some("stage-id"));
+        assert_eq!(retained[1].parent_id(), Some("req-id"));
         assert_eq!(
             retained[1].fields().get("custom"),
             Some(&FieldValue::String("stage-custom".to_owned()))
@@ -2896,8 +2896,8 @@ mod tests {
             retained[1].fields().get("tt.stage"),
             Some(&FieldValue::String("db".to_owned()))
         );
-        assert_eq!(retained[2].id_ref(), Some("queue-id"));
-        assert_eq!(retained[2].parent_id_ref(), Some("req-id"));
+        assert_eq!(retained[2].id(), Some("queue-id"));
+        assert_eq!(retained[2].parent_id(), Some("req-id"));
         assert_eq!(
             retained[2].fields().get("custom"),
             Some(&FieldValue::String("queue-custom".to_owned()))
@@ -2915,12 +2915,12 @@ mod tests {
             let recorder = LiveRecorder::builder("svc").run_id("rid").build().unwrap();
             recorder.state.lock().unwrap().completed_requests.push(
                 SpanRecord::new("request", 100, 120)
-                    .id("req-id")
-                    .field(TT_KIND, "request")
-                    .field("tt.request_id", "r1")
-                    .field("tt.route", "/a")
-                    .field("tt.outcome", "ok")
-                    .field("custom", "kept"),
+                    .with_id("req-id")
+                    .with_field(TT_KIND, "request")
+                    .with_field("tt.request_id", "r1")
+                    .with_field("tt.route", "/a")
+                    .with_field("tt.outcome", "ok")
+                    .with_field("custom", "kept"),
             );
             recorder
         };
@@ -3042,7 +3042,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_errors_when_max_open_spans_drops_candidate_spans() {
+    fn strict_errors_when_max_open_spans_drops_candidate_spans() {
         let recorder = LiveRecorder::builder("svc")
             .strict(true)
             .max_open_spans(1)
@@ -3080,7 +3080,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_combines_recorder_drop_and_conversion_strict_violations() {
+    fn strict_combines_recorder_drop_and_conversion_strict_violations() {
         let recorder = LiveRecorder::builder("svc")
             .strict(true)
             .capture_limits(tailtriage_core::CaptureLimits {
@@ -3118,7 +3118,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn incomplete_request_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
+    fn incomplete_request_does_not_consume_completed_candidate_cap_in_non_strict() {
         let recorder = LiveRecorder::builder("svc")
             .max_completed_candidate_spans(1)
             .build()
@@ -3152,7 +3152,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn incomplete_stage_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
+    fn incomplete_stage_does_not_consume_completed_candidate_cap_in_non_strict() {
         let recorder = LiveRecorder::builder("svc")
             .max_completed_candidate_spans(2)
             .build()
@@ -3198,7 +3198,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn incomplete_queue_does_not_consume_completed_candidate_cap_in_non_strict_mode() {
+    fn incomplete_queue_does_not_consume_completed_candidate_cap_in_non_strict() {
         let recorder = LiveRecorder::builder("svc")
             .max_completed_candidate_spans(2)
             .build()
@@ -3476,7 +3476,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_fails_for_malformed_request_span() {
+    fn strict_fails_for_malformed_request_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -3492,7 +3492,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_fails_for_invalid_numeric_request_route() {
+    fn strict_fails_for_invalid_numeric_request_route() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -3514,7 +3514,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_fails_for_malformed_stage_span() {
+    fn strict_fails_for_malformed_stage_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -3537,7 +3537,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_fails_for_invalid_numeric_stage_field() {
+    fn strict_fails_for_invalid_numeric_stage_field() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -3566,7 +3566,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_fails_for_malformed_queue_span() {
+    fn strict_fails_for_malformed_queue_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -3589,7 +3589,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_fails_for_invalid_numeric_queue_field() {
+    fn strict_fails_for_invalid_numeric_queue_field() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -3618,7 +3618,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_fails_for_orphan_stage_span() {
+    fn strict_fails_for_orphan_stage_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -3635,7 +3635,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_fails_for_orphan_queue_span() {
+    fn strict_fails_for_orphan_queue_span() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -3691,7 +3691,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn non_strict_mode_reports_drop_warnings_and_truncation() {
+    fn non_strict_reports_drop_warnings_and_truncation() {
         let recorder = LiveRecorder::builder("svc")
             .max_open_spans(1)
             .capture_limits(tailtriage_core::CaptureLimits {
@@ -3965,7 +3965,7 @@ mod tests {
 
     // TT-TEST: support
     #[test]
-    fn strict_mode_reports_open_and_closed_missing_kind_causes_together() {
+    fn strict_reports_open_and_closed_missing_kind_causes_together() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -4011,7 +4011,7 @@ mod tests {
     }
     // TT-TEST: support
     #[test]
-    fn strict_mode_rejects_open_candidate_spans_without_fabricating_completions() {
+    fn strict_rejects_open_candidate_spans_without_fabricating_completions() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         let err = tracing::subscriber::with_default(subscriber, || {
@@ -4064,7 +4064,7 @@ mod tests {
 
     // TT-TEST: R03 primary
     #[test]
-    fn open_candidate_span_errors_in_strict_mode() {
+    fn open_candidate_span_errors_in_strict() {
         let recorder = LiveRecorder::builder("svc").strict(true).build().unwrap();
         let subscriber = tracing_subscriber::registry().with(recorder.layer());
         tracing::subscriber::with_default(subscriber, || {
@@ -4110,37 +4110,37 @@ mod tests {
         let second_path = dir.path().join("second.jsonl");
         let sources = vec![
             SpanRecord::new("request-source", 1_700_000_000_001, 1_700_000_000_051)
-                .id("req-span")
-                .parent_id("root-span")
-                .started_at_run_us(10)
-                .finished_at_run_us(50_010)
-                .duration_us(50_000)
-                .field(TT_KIND, "request")
-                .field("tt.request_id", "r1")
-                .field("tt.route", "/exact")
-                .field("tt.outcome", "ok")
-                .field("custom.string", "value")
-                .field("custom.bool", true)
-                .field("custom.u64", 7_u64),
+                .with_id("req-span")
+                .with_parent_id("root-span")
+                .with_started_at_run_us(10)
+                .with_finished_at_run_us(50_010)
+                .with_duration_us(50_000)
+                .with_field(TT_KIND, "request")
+                .with_field("tt.request_id", "r1")
+                .with_field("tt.route", "/exact")
+                .with_field("tt.outcome", "ok")
+                .with_field("custom.string", "value")
+                .with_field("custom.bool", true)
+                .with_field("custom.u64", 7_u64),
             SpanRecord::new("stage-source", 1_700_000_000_010, 1_700_000_000_020)
-                .id("stage-span")
-                .parent_id("req-span")
-                .started_at_run_us(9_000)
-                .finished_at_run_us(19_000)
-                .duration_us(10_000)
-                .field(TT_KIND, "stage")
-                .field("tt.request_id", "r1")
-                .field("tt.stage", "db")
-                .field("custom.i64", -3_i64)
-                .field("custom.f64", 1.25_f64),
+                .with_id("stage-span")
+                .with_parent_id("req-span")
+                .with_started_at_run_us(9_000)
+                .with_finished_at_run_us(19_000)
+                .with_duration_us(10_000)
+                .with_field(TT_KIND, "stage")
+                .with_field("tt.request_id", "r1")
+                .with_field("tt.stage", "db")
+                .with_field("custom.i64", -3_i64)
+                .with_field("custom.f64", 1.25_f64),
             SpanRecord::new("queue-source", 1_700_000_000_021, 1_700_000_000_025)
-                .id("queue-span")
-                .parent_id("req-span")
-                .duration_us(4_000)
-                .field(TT_KIND, "queue")
-                .field("tt.request_id", "r1")
-                .field("tt.queue", "permits")
-                .field("custom.null", FieldValue::Null),
+                .with_id("queue-span")
+                .with_parent_id("req-span")
+                .with_duration_us(4_000)
+                .with_field(TT_KIND, "queue")
+                .with_field("tt.request_id", "r1")
+                .with_field("tt.queue", "permits")
+                .with_field("custom.null", FieldValue::Null),
         ];
 
         write_completed_span_jsonl_from_retained_sources(&sources, &first_path).unwrap();
@@ -4170,10 +4170,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let exact_path = dir.path().join("exact.jsonl");
         let source = SpanRecord::new("request", 1, 2)
-            .field(TT_KIND, "request")
-            .field("tt.request_id", "r1")
-            .field("tt.route", "/")
-            .field("padding", "x".repeat(256));
+            .with_field(TT_KIND, "request")
+            .with_field("tt.request_id", "r1")
+            .with_field("tt.route", "/")
+            .with_field("padding", "x".repeat(256));
         let wrapped = serde_json::json!({
             "format": "tailtriage.tracing-span.v1",
             "span": &source,
@@ -4226,7 +4226,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("oversize.jsonl");
         let small = SpanRecord::new("small", 1, 2);
-        let large = SpanRecord::new("large", 1, 2).field("padding", "x".repeat(256));
+        let large = SpanRecord::new("large", 1, 2).with_field("padding", "x".repeat(256));
         let small_len = serde_json::to_vec(&serde_json::json!({
             "format": "tailtriage.tracing-span.v1",
             "span": &small,
@@ -4255,7 +4255,7 @@ mod tests {
         std::fs::write(&path, sentinel).unwrap();
 
         let small = SpanRecord::new("small", 1, 2);
-        let large = SpanRecord::new("large", 1, 2).field("padding", "x".repeat(256));
+        let large = SpanRecord::new("large", 1, 2).with_field("padding", "x".repeat(256));
         let small_len = serde_json::to_vec(&serde_json::json!({
             "format": "tailtriage.tracing-span.v1",
             "span": &small,
@@ -4377,15 +4377,15 @@ mod tests {
         let spans_path = dir.path().join("completed.jsonl");
         let sources = vec![
             SpanRecord::new("http.request", 1_700_000_000_000, 1_700_000_000_120)
-                .id("span-id")
-                .parent_id("parent-id")
-                .started_at_run_us(10)
-                .finished_at_run_us(120_010)
-                .duration_us(120_000)
-                .field(TT_KIND, "request")
-                .field("tt.request_id", "req-1")
-                .field("tt.route", "/checkout")
-                .field("custom.source", "kept"),
+                .with_id("span-id")
+                .with_parent_id("parent-id")
+                .with_started_at_run_us(10)
+                .with_finished_at_run_us(120_010)
+                .with_duration_us(120_000)
+                .with_field(TT_KIND, "request")
+                .with_field("tt.request_id", "req-1")
+                .with_field("tt.route", "/checkout")
+                .with_field("custom.source", "kept"),
         ];
 
         write_completed_span_jsonl_from_retained_sources(&sources, &spans_path).unwrap();
@@ -4394,14 +4394,14 @@ mod tests {
         let retained = imported.retained_sources();
         assert_eq!(retained.len(), 1);
         let span = &retained[0];
-        assert_eq!(span.id_ref(), Some("span-id"));
-        assert_eq!(span.parent_id_ref(), Some("parent-id"));
+        assert_eq!(span.id(), Some("span-id"));
+        assert_eq!(span.parent_id(), Some("parent-id"));
         assert_eq!(span.name(), "http.request");
         assert_eq!(span.started_at_unix_ms(), 1_700_000_000_000);
         assert_eq!(span.finished_at_unix_ms(), 1_700_000_000_120);
-        assert_eq!(span.started_at_run_us_ref(), Some(10));
-        assert_eq!(span.finished_at_run_us_ref(), Some(120_010));
-        assert_eq!(span.duration_us_ref(), Some(120_000));
+        assert_eq!(span.started_at_run_us(), Some(10));
+        assert_eq!(span.finished_at_run_us(), Some(120_010));
+        assert_eq!(span.duration_us(), Some(120_000));
         assert_eq!(
             span.fields().get(TT_KIND),
             Some(&FieldValue::String("request".to_owned()))
@@ -4427,55 +4427,55 @@ mod tests {
         let spans_path = dir.path().join("spans.jsonl");
         let sources = vec![
             SpanRecord::new("duplicate-request-a", 100, 150)
-                .id("dup-a")
-                .field(TT_KIND, "request")
-                .field("tt.request_id", "dup")
-                .field("tt.route", "/dup-a"),
+                .with_id("dup-a")
+                .with_field(TT_KIND, "request")
+                .with_field("tt.request_id", "dup")
+                .with_field("tt.route", "/dup-a"),
             SpanRecord::new("duplicate-request-b", 101, 151)
-                .id("dup-b")
-                .field(TT_KIND, "request")
-                .field("tt.request_id", "dup")
-                .field("tt.route", "/dup-b"),
+                .with_id("dup-b")
+                .with_field(TT_KIND, "request")
+                .with_field("tt.request_id", "dup")
+                .with_field("tt.route", "/dup-b"),
             SpanRecord::new("ambiguous-child", 110, 120)
-                .id("ambiguous")
-                .parent_id("dup-a")
-                .field(TT_KIND, "stage")
-                .field("tt.request_id", "dup")
-                .field("tt.stage", "ambiguous"),
+                .with_id("ambiguous")
+                .with_parent_id("dup-a")
+                .with_field(TT_KIND, "stage")
+                .with_field("tt.request_id", "dup")
+                .with_field("tt.stage", "ambiguous"),
             SpanRecord::new("orphan-child", 110, 120)
-                .id("orphan")
-                .field(TT_KIND, "queue")
-                .field("tt.request_id", "missing")
-                .field("tt.queue", "orphan"),
+                .with_id("orphan")
+                .with_field(TT_KIND, "queue")
+                .with_field("tt.request_id", "missing")
+                .with_field("tt.queue", "orphan"),
             SpanRecord::new("child-of-excluded-parent", 111, 121)
-                .id("excluded-child")
-                .parent_id("dup-a")
-                .field(TT_KIND, "queue")
-                .field("tt.request_id", "dup")
-                .field("tt.queue", "excluded-parent"),
+                .with_id("excluded-child")
+                .with_parent_id("dup-a")
+                .with_field(TT_KIND, "queue")
+                .with_field("tt.request_id", "dup")
+                .with_field("tt.queue", "excluded-parent"),
             SpanRecord::new("valid-request", 200, 300)
-                .id("valid-req")
-                .started_at_run_us(0)
-                .finished_at_run_us(100_000)
-                .field(TT_KIND, "request")
-                .field("tt.request_id", "ok")
-                .field("tt.route", "/ok"),
+                .with_id("valid-req")
+                .with_started_at_run_us(0)
+                .with_finished_at_run_us(100_000)
+                .with_field(TT_KIND, "request")
+                .with_field("tt.request_id", "ok")
+                .with_field("tt.route", "/ok"),
             SpanRecord::new("outside-child", 301, 310)
-                .id("outside")
-                .parent_id("valid-req")
-                .started_at_run_us(101_000)
-                .finished_at_run_us(110_000)
-                .field(TT_KIND, "stage")
-                .field("tt.request_id", "ok")
-                .field("tt.stage", "outside"),
+                .with_id("outside")
+                .with_parent_id("valid-req")
+                .with_started_at_run_us(101_000)
+                .with_finished_at_run_us(110_000)
+                .with_field(TT_KIND, "stage")
+                .with_field("tt.request_id", "ok")
+                .with_field("tt.stage", "outside"),
             SpanRecord::new("valid-child", 210, 220)
-                .id("valid-child")
-                .parent_id("valid-req")
-                .started_at_run_us(10_000)
-                .finished_at_run_us(20_000)
-                .field(TT_KIND, "stage")
-                .field("tt.request_id", "ok")
-                .field("tt.stage", "inside"),
+                .with_id("valid-child")
+                .with_parent_id("valid-req")
+                .with_started_at_run_us(10_000)
+                .with_finished_at_run_us(20_000)
+                .with_field(TT_KIND, "stage")
+                .with_field("tt.request_id", "ok")
+                .with_field("tt.stage", "inside"),
         ];
         let imported = run_from_span_records(sources, ImportOptions::new("svc")).unwrap();
 
@@ -4493,30 +4493,30 @@ mod tests {
 
     fn request(name: &str, id: &str, start: u64, finish: u64) -> SpanRecord {
         SpanRecord::new(name, start, finish)
-            .id(format!("{id}-span"))
-            .field(TT_KIND, "request")
-            .field("tt.request_id", id)
-            .field("tt.route", format!("/{id}"))
-            .field("tt.outcome", "ok")
+            .with_id(format!("{id}-span"))
+            .with_field(TT_KIND, "request")
+            .with_field("tt.request_id", id)
+            .with_field("tt.route", format!("/{id}"))
+            .with_field("tt.outcome", "ok")
     }
 
     fn stage(name: &str, id: &str, start: u64, finish: u64) -> SpanRecord {
         SpanRecord::new(name, start, finish)
-            .id(format!("{name}-span"))
-            .parent_id(format!("{id}-span"))
-            .field(TT_KIND, "stage")
-            .field("tt.request_id", id)
-            .field("tt.stage", name)
-            .field("tt.success", true)
+            .with_id(format!("{name}-span"))
+            .with_parent_id(format!("{id}-span"))
+            .with_field(TT_KIND, "stage")
+            .with_field("tt.request_id", id)
+            .with_field("tt.stage", name)
+            .with_field("tt.success", true)
     }
 
     fn queue(name: &str, id: &str, start: u64, finish: u64) -> SpanRecord {
         SpanRecord::new(name, start, finish)
-            .id(format!("{name}-span"))
-            .parent_id(format!("{id}-span"))
-            .field(TT_KIND, "queue")
-            .field("tt.request_id", id)
-            .field("tt.queue", name)
+            .with_id(format!("{name}-span"))
+            .with_parent_id(format!("{id}-span"))
+            .with_field(TT_KIND, "queue")
+            .with_field("tt.request_id", id)
+            .with_field("tt.queue", name)
     }
 
     // TT-TEST: R06 secondary
@@ -4551,28 +4551,28 @@ mod tests {
                 name: "precise custom identity and fields",
                 spans: vec![
                     request("custom-http", "precise", 1_000, 1_050)
-                        .id("req-custom")
-                        .parent_id("root")
-                        .started_at_run_us(10)
-                        .finished_at_run_us(50_010)
-                        .duration_us(50_000)
-                        .field("custom.string", "kept")
-                        .field("custom.u64", 42_u64),
+                        .with_id("req-custom")
+                        .with_parent_id("root")
+                        .with_started_at_run_us(10)
+                        .with_finished_at_run_us(50_010)
+                        .with_duration_us(50_000)
+                        .with_field("custom.string", "kept")
+                        .with_field("custom.u64", 42_u64),
                     stage("custom-db", "precise", 1_010, 1_030)
-                        .id("stage-custom")
-                        .parent_id("req-custom")
-                        .started_at_run_us(10_010)
-                        .finished_at_run_us(30_010)
-                        .duration_us(20_000)
-                        .field("custom.bool", false),
+                        .with_id("stage-custom")
+                        .with_parent_id("req-custom")
+                        .with_started_at_run_us(10_010)
+                        .with_finished_at_run_us(30_010)
+                        .with_duration_us(20_000)
+                        .with_field("custom.bool", false),
                     queue("custom-permits", "precise", 1_031, 1_040)
-                        .id("queue-custom")
-                        .parent_id("req-custom")
-                        .started_at_run_us(31_010)
-                        .finished_at_run_us(40_010)
-                        .duration_us(9_000)
-                        .field("tt.depth_at_start", 8_u64)
-                        .field("custom.null", FieldValue::Null),
+                        .with_id("queue-custom")
+                        .with_parent_id("req-custom")
+                        .with_started_at_run_us(31_010)
+                        .with_finished_at_run_us(40_010)
+                        .with_duration_us(9_000)
+                        .with_field("tt.depth_at_start", 8_u64)
+                        .with_field("custom.null", FieldValue::Null),
                 ],
                 options: ImportOptions::new("svc"),
                 strict_replay: true,
@@ -4581,9 +4581,9 @@ mod tests {
             Case {
                 name: "duration only",
                 spans: vec![
-                    request("duration-request", "duration", 2_000, 2_050).duration_us(123_456),
-                    stage("duration-stage", "duration", 2_010, 2_020).duration_us(10_000),
-                    queue("duration-queue", "duration", 2_021, 2_025).duration_us(4_000),
+                    request("duration-request", "duration", 2_000, 2_050).with_duration_us(123_456),
+                    stage("duration-stage", "duration", 2_010, 2_020).with_duration_us(10_000),
+                    queue("duration-queue", "duration", 2_021, 2_025).with_duration_us(4_000),
                 ],
                 options: ImportOptions::new("svc"),
                 strict_replay: true,
@@ -4593,17 +4593,17 @@ mod tests {
                 name: "repairable optional offsets",
                 spans: vec![
                     request("repair-request", "repair", 3_000, 3_050)
-                        .started_at_run_us(50)
-                        .finished_at_run_us(10)
-                        .duration_us(50_000),
+                        .with_started_at_run_us(50)
+                        .with_finished_at_run_us(10)
+                        .with_duration_us(50_000),
                     stage("repair-stage", "repair", 3_010, 3_020)
-                        .started_at_run_us(20)
-                        .finished_at_run_us(15)
-                        .duration_us(10_000),
+                        .with_started_at_run_us(20)
+                        .with_finished_at_run_us(15)
+                        .with_duration_us(10_000),
                     queue("repair-queue", "repair", 3_021, 3_030)
-                        .started_at_run_us(30)
-                        .finished_at_run_us(25)
-                        .duration_us(9_000),
+                        .with_started_at_run_us(30)
+                        .with_finished_at_run_us(25)
+                        .with_duration_us(9_000),
                 ],
                 options: ImportOptions::new("svc"),
                 strict_replay: false,
@@ -4637,10 +4637,10 @@ mod tests {
                 name: "source parser inverted parent leaves child orphan",
                 spans: vec![
                     SpanRecord::new("invalid-parent", 6_050, 6_000)
-                        .id("invalid-parent-span")
-                        .field(TT_KIND, "request")
-                        .field("tt.request_id", "bad-parent")
-                        .field("tt.route", "/bad-parent"),
+                        .with_id("invalid-parent-span")
+                        .with_field(TT_KIND, "request")
+                        .with_field("tt.request_id", "bad-parent")
+                        .with_field("tt.route", "/bad-parent"),
                     stage(
                         "child-of-parser-rejected-parent",
                         "bad-parent",
@@ -4662,14 +4662,14 @@ mod tests {
                 name: "contained parent with precise outside child",
                 spans: vec![
                     request("containment-parent", "contained", 7_000, 7_050)
-                        .started_at_run_us(0)
-                        .finished_at_run_us(50_000),
+                        .with_started_at_run_us(0)
+                        .with_finished_at_run_us(50_000),
                     stage("outside-stage", "contained", 7_060, 7_070)
-                        .started_at_run_us(60_000)
-                        .finished_at_run_us(70_000),
+                        .with_started_at_run_us(60_000)
+                        .with_finished_at_run_us(70_000),
                     queue("inside-queue", "contained", 7_010, 7_020)
-                        .started_at_run_us(10_000)
-                        .finished_at_run_us(20_000),
+                        .with_started_at_run_us(10_000)
+                        .with_finished_at_run_us(20_000),
                 ],
                 options: ImportOptions::new("svc"),
                 strict_replay: false,
@@ -4779,22 +4779,22 @@ mod tests {
         let second_path = dir.path().join("reemitted.jsonl");
         let sources = vec![
             request("repairable-request", "repair", 1_000, 1_020)
-                .id("repairable-request")
-                .started_at_run_us(50)
-                .finished_at_run_us(10)
-                .duration_us(20_000),
+                .with_id("repairable-request")
+                .with_started_at_run_us(50)
+                .with_finished_at_run_us(10)
+                .with_duration_us(20_000),
             stage("repairable-stage", "repair", 1_005, 1_015)
-                .id("repairable-stage")
-                .parent_id("repairable-request")
-                .started_at_run_us(40)
-                .finished_at_run_us(20)
-                .duration_us(10_000),
+                .with_id("repairable-stage")
+                .with_parent_id("repairable-request")
+                .with_started_at_run_us(40)
+                .with_finished_at_run_us(20)
+                .with_duration_us(10_000),
             queue("repairable-queue", "repair", 1_006, 1_012)
-                .id("repairable-queue")
-                .parent_id("repairable-request")
-                .started_at_run_us(35)
-                .finished_at_run_us(25)
-                .duration_us(6_000),
+                .with_id("repairable-queue")
+                .with_parent_id("repairable-request")
+                .with_started_at_run_us(35)
+                .with_finished_at_run_us(25)
+                .with_duration_us(6_000),
         ];
 
         let direct_provenance =
@@ -4905,45 +4905,45 @@ mod tests {
             let mut state = semantic_session.recorder.state.lock().unwrap();
             state.completed_requests.push(
                 SpanRecord::new("sem-request-kept", 100, 200)
-                    .id("sr1")
-                    .field(TT_KIND, "request")
-                    .field("tt.request_id", "sr1")
-                    .field("tt.route", "/one"),
+                    .with_id("sr1")
+                    .with_field(TT_KIND, "request")
+                    .with_field("tt.request_id", "sr1")
+                    .with_field("tt.route", "/one"),
             );
             state.completed_requests.push(
                 SpanRecord::new("sem-request-dropped", 101, 201)
-                    .id("sr2")
-                    .field(TT_KIND, "request")
-                    .field("tt.request_id", "sr2")
-                    .field("tt.route", "/two"),
+                    .with_id("sr2")
+                    .with_field(TT_KIND, "request")
+                    .with_field("tt.request_id", "sr2")
+                    .with_field("tt.route", "/two"),
             );
             state.completed_stages.push(
                 SpanRecord::new("sem-stage-kept", 110, 120)
-                    .id("ss1")
-                    .field(TT_KIND, "stage")
-                    .field("tt.request_id", "sr1")
-                    .field("tt.stage", "db"),
+                    .with_id("ss1")
+                    .with_field(TT_KIND, "stage")
+                    .with_field("tt.request_id", "sr1")
+                    .with_field("tt.stage", "db"),
             );
             state.completed_stages.push(
                 SpanRecord::new("sem-stage-dropped", 121, 130)
-                    .id("ss2")
-                    .field(TT_KIND, "stage")
-                    .field("tt.request_id", "sr1")
-                    .field("tt.stage", "cache"),
+                    .with_id("ss2")
+                    .with_field(TT_KIND, "stage")
+                    .with_field("tt.request_id", "sr1")
+                    .with_field("tt.stage", "cache"),
             );
             state.completed_queues.push(
                 SpanRecord::new("sem-queue-kept", 130, 140)
-                    .id("sq1")
-                    .field(TT_KIND, "queue")
-                    .field("tt.request_id", "sr1")
-                    .field("tt.queue", "permits"),
+                    .with_id("sq1")
+                    .with_field(TT_KIND, "queue")
+                    .with_field("tt.request_id", "sr1")
+                    .with_field("tt.queue", "permits"),
             );
             state.completed_queues.push(
                 SpanRecord::new("sem-queue-dropped", 141, 150)
-                    .id("sq2")
-                    .field(TT_KIND, "queue")
-                    .field("tt.request_id", "sr1")
-                    .field("tt.queue", "work"),
+                    .with_id("sq2")
+                    .with_field(TT_KIND, "queue")
+                    .with_field("tt.request_id", "sr1")
+                    .with_field("tt.queue", "work"),
             );
         }
         let semantic_snapshot = semantic_session.snapshot_run().unwrap();
@@ -5030,28 +5030,28 @@ mod tests {
             let mut state = session.recorder.state.lock().unwrap();
             state.completed_stages.push(
                 SpanRecord::new("live-stage-first", 10, 20)
-                    .started_at_run_us(10_000)
-                    .finished_at_run_us(20_000)
-                    .field(TT_KIND, "stage")
-                    .field("tt.request_id", "live-1")
-                    .field("tt.stage", "db"),
+                    .with_started_at_run_us(10_000)
+                    .with_finished_at_run_us(20_000)
+                    .with_field(TT_KIND, "stage")
+                    .with_field("tt.request_id", "live-1")
+                    .with_field("tt.stage", "db"),
             );
             state.completed_queues.push(
                 SpanRecord::new("live-queue-second", 21, 25)
-                    .started_at_run_us(21_000)
-                    .finished_at_run_us(25_000)
-                    .field(TT_KIND, "queue")
-                    .field("tt.request_id", "live-1")
-                    .field("tt.queue", "permits"),
+                    .with_started_at_run_us(21_000)
+                    .with_finished_at_run_us(25_000)
+                    .with_field(TT_KIND, "queue")
+                    .with_field("tt.request_id", "live-1")
+                    .with_field("tt.queue", "permits"),
             );
             state.completed_requests.push(
                 SpanRecord::new("live-request-third", 1, 50)
-                    .started_at_run_us(1_000)
-                    .finished_at_run_us(50_000)
-                    .field(TT_KIND, "request")
-                    .field("tt.request_id", "live-1")
-                    .field("tt.route", "/live")
-                    .field("custom", "identity"),
+                    .with_started_at_run_us(1_000)
+                    .with_finished_at_run_us(50_000)
+                    .with_field(TT_KIND, "request")
+                    .with_field("tt.request_id", "live-1")
+                    .with_field("tt.route", "/live")
+                    .with_field("custom", "identity"),
             );
         }
         futures_executor::block_on(session.shutdown()).unwrap()
@@ -5130,35 +5130,35 @@ mod tests {
             "precise",
             vec![
                 request("precise-reemit-request", "reemit", 10, 30)
-                    .id("precise-req")
-                    .parent_id("root")
-                    .started_at_run_us(1)
-                    .finished_at_run_us(20_001)
-                    .duration_us(20_000)
-                    .field("custom", "kept"),
+                    .with_id("precise-req")
+                    .with_parent_id("root")
+                    .with_started_at_run_us(1)
+                    .with_finished_at_run_us(20_001)
+                    .with_duration_us(20_000)
+                    .with_field("custom", "kept"),
                 stage("precise-reemit-stage", "reemit", 12, 20)
-                    .id("precise-stage")
-                    .parent_id("precise-req"),
+                    .with_id("precise-stage")
+                    .with_parent_id("precise-req"),
                 queue("precise-reemit-queue", "reemit", 21, 25)
-                    .id("precise-queue")
-                    .parent_id("precise-req"),
+                    .with_id("precise-queue")
+                    .with_parent_id("precise-req"),
             ],
         );
         assert_stable_wrapper_reemits_byte_identically(
             "repair",
             vec![
                 request("repair-reemit-request", "repair-reemit", 40, 80)
-                    .started_at_run_us(50)
-                    .finished_at_run_us(10)
-                    .duration_us(40_000),
+                    .with_started_at_run_us(50)
+                    .with_finished_at_run_us(10)
+                    .with_duration_us(40_000),
                 stage("repair-reemit-stage", "repair-reemit", 45, 55)
-                    .started_at_run_us(20)
-                    .finished_at_run_us(15)
-                    .duration_us(10_000),
+                    .with_started_at_run_us(20)
+                    .with_finished_at_run_us(15)
+                    .with_duration_us(10_000),
                 queue("repair-reemit-queue", "repair-reemit", 56, 60)
-                    .started_at_run_us(30)
-                    .finished_at_run_us(25)
-                    .duration_us(4_000),
+                    .with_started_at_run_us(30)
+                    .with_finished_at_run_us(25)
+                    .with_duration_us(4_000),
             ],
         );
     }
@@ -5247,9 +5247,9 @@ mod tests {
         let spans_path = dir.path().join("spans.jsonl");
         let imported = run_from_span_records(
             vec![SpanRecord::new("request", 100, 200)
-                .field(TT_KIND, "request")
-                .field("tt.request_id", "r1")
-                .field("tt.route", "/a")],
+                .with_field(TT_KIND, "request")
+                .with_field("tt.request_id", "r1")
+                .with_field("tt.route", "/a")],
             ImportOptions::new("svc"),
         )
         .unwrap();

--- a/tailtriage-tracing/src/types.rs
+++ b/tailtriage-tracing/src/types.rs
@@ -118,53 +118,53 @@ impl SpanRecord {
 
     /// Sets a span identifier.
     #[must_use]
-    pub fn id(mut self, id: impl Into<String>) -> Self {
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
         self.id = Some(id.into());
         self
     }
 
     /// Sets the optional parent span identifier.
     #[must_use]
-    pub fn parent_id(mut self, parent_id: impl Into<String>) -> Self {
+    pub fn with_parent_id(mut self, parent_id: impl Into<String>) -> Self {
         self.parent_id = Some(parent_id.into());
         self
     }
 
     /// Adds or replaces a field.
     #[must_use]
-    pub fn field(mut self, key: impl Into<String>, value: impl Into<FieldValue>) -> Self {
+    pub fn with_field(mut self, key: impl Into<String>, value: impl Into<FieldValue>) -> Self {
         self.fields.insert(key.into(), value.into());
         self
     }
     /// Sets span start offset from run start in microseconds.
     #[must_use]
-    pub fn started_at_run_us(mut self, started_at_run_us: u64) -> Self {
+    pub fn with_started_at_run_us(mut self, started_at_run_us: u64) -> Self {
         self.started_at_run_us = Some(started_at_run_us);
         self
     }
 
     /// Sets span finish offset from run start in microseconds.
     #[must_use]
-    pub fn finished_at_run_us(mut self, finished_at_run_us: u64) -> Self {
+    pub fn with_finished_at_run_us(mut self, finished_at_run_us: u64) -> Self {
         self.finished_at_run_us = Some(finished_at_run_us);
         self
     }
 
     /// Sets explicit span duration in microseconds.
     #[must_use]
-    pub fn duration_us(mut self, duration_us: u64) -> Self {
+    pub fn with_duration_us(mut self, duration_us: u64) -> Self {
         self.duration_us = Some(duration_us);
         self
     }
 
     /// Returns span id if present.
     #[must_use]
-    pub fn id_ref(&self) -> Option<&str> {
+    pub fn id(&self) -> Option<&str> {
         self.id.as_deref()
     }
     /// Returns parent span id if present.
     #[must_use]
-    pub fn parent_id_ref(&self) -> Option<&str> {
+    pub fn parent_id(&self) -> Option<&str> {
         self.parent_id.as_deref()
     }
     /// Returns span name.
@@ -184,7 +184,7 @@ impl SpanRecord {
     }
     /// Returns span start offset from run start in microseconds when present.
     #[must_use]
-    pub fn started_at_run_us_ref(&self) -> Option<u64> {
+    pub fn started_at_run_us(&self) -> Option<u64> {
         self.started_at_run_us
     }
     /// Returns finish timestamp in unix milliseconds.
@@ -194,12 +194,12 @@ impl SpanRecord {
     }
     /// Returns span finish offset from run start in microseconds when present.
     #[must_use]
-    pub fn finished_at_run_us_ref(&self) -> Option<u64> {
+    pub fn finished_at_run_us(&self) -> Option<u64> {
         self.finished_at_run_us
     }
     /// Returns explicit span duration in microseconds when present.
     #[must_use]
-    pub fn duration_us_ref(&self) -> Option<u64> {
+    pub fn duration_us(&self) -> Option<u64> {
         self.duration_us
     }
 }
@@ -283,17 +283,17 @@ impl ImportOptions {
     }
     /// Returns service version.
     #[must_use]
-    pub fn service_version_ref(&self) -> Option<&str> {
+    pub fn configured_service_version(&self) -> Option<&str> {
         self.service_version.as_deref()
     }
     /// Returns run id.
     #[must_use]
-    pub fn run_id_ref(&self) -> Option<&str> {
+    pub fn configured_run_id(&self) -> Option<&str> {
         self.run_id.as_deref()
     }
     /// Returns strict mode setting.
     #[must_use]
-    pub fn strict_mode(&self) -> bool {
+    pub fn is_strict(&self) -> bool {
         self.strict
     }
 
@@ -308,7 +308,7 @@ impl ImportOptions {
 
     /// Returns capture mode setting.
     #[must_use]
-    pub fn mode_value(&self) -> tailtriage_core::CaptureMode {
+    pub fn capture_mode(&self) -> tailtriage_core::CaptureMode {
         self.mode
     }
 }
@@ -322,7 +322,7 @@ pub struct ImportWarning {
 
 impl ImportWarning {
     /// Creates a warning message.
-    pub fn new(message: impl Into<String>) -> Self {
+    pub(crate) fn new(message: impl Into<String>) -> Self {
         Self {
             message: message.into(),
         }
@@ -353,7 +353,8 @@ pub struct ImportedRun {
 impl ImportedRun {
     /// Creates imported output from a converted run and non-fatal warnings.
     #[must_use]
-    pub fn new(run: tailtriage_core::Run, warnings: Vec<ImportWarning>) -> Self {
+    #[allow(dead_code)]
+    pub(crate) fn new(run: tailtriage_core::Run, warnings: Vec<ImportWarning>) -> Self {
         Self {
             run,
             warnings,
@@ -413,22 +414,22 @@ mod tests {
     #[test]
     fn span_record_builder_stores_fields() {
         let record = SpanRecord::new("request", 10, 20)
-            .id("span-1")
-            .parent_id("parent-1")
-            .started_at_run_us(100)
-            .finished_at_run_us(200)
-            .field("tt.request_id", "req-1")
-            .field(TT_KIND, "request")
-            .field(TT_SUCCESS, true)
-            .field(TT_DEPTH_AT_START, 7_u64);
+            .with_id("span-1")
+            .with_parent_id("parent-1")
+            .with_started_at_run_us(100)
+            .with_finished_at_run_us(200)
+            .with_field("tt.request_id", "req-1")
+            .with_field(TT_KIND, "request")
+            .with_field(TT_SUCCESS, true)
+            .with_field(TT_DEPTH_AT_START, 7_u64);
 
-        assert_eq!(record.id_ref(), Some("span-1"));
-        assert_eq!(record.parent_id_ref(), Some("parent-1"));
+        assert_eq!(record.id(), Some("span-1"));
+        assert_eq!(record.parent_id(), Some("parent-1"));
         assert_eq!(record.name(), "request");
         assert_eq!(record.started_at_unix_ms(), 10);
-        assert_eq!(record.started_at_run_us_ref(), Some(100));
+        assert_eq!(record.started_at_run_us(), Some(100));
         assert_eq!(record.finished_at_unix_ms(), 20);
-        assert_eq!(record.finished_at_run_us_ref(), Some(200));
+        assert_eq!(record.finished_at_run_us(), Some(200));
         assert_eq!(record.fields().len(), 4);
     }
 
@@ -458,9 +459,9 @@ mod tests {
             .strict(true);
 
         assert_eq!(options.service_name(), "checkout-service");
-        assert_eq!(options.service_version_ref(), Some("1.2.3"));
-        assert_eq!(options.run_id_ref(), Some("run-123"));
-        assert!(options.strict_mode());
+        assert_eq!(options.configured_service_version(), Some("1.2.3"));
+        assert_eq!(options.configured_run_id(), Some("run-123"));
+        assert!(options.is_strict());
     }
 
     // TT-TEST: support
@@ -504,7 +505,7 @@ mod tests {
     #[test]
     fn import_options_default_resolution_uses_light_core_defaults() {
         let options = ImportOptions::new("svc");
-        assert_eq!(options.mode_value(), tailtriage_core::CaptureMode::Light);
+        assert_eq!(options.capture_mode(), tailtriage_core::CaptureMode::Light);
         assert_eq!(
             options.resolved_capture_limits(),
             tailtriage_core::CaptureMode::Light.core_defaults()

--- a/tailtriage-tracing/tests/support/live_harness.rs
+++ b/tailtriage-tracing/tests/support/live_harness.rs
@@ -197,43 +197,43 @@ fn deterministic_tracing_run() -> (Run, Vec<String>) {
         let req_run_start_us = offset_ms * 1000;
         spans.push(
             SpanRecord::new("request", req_start, req_start + (request_us / 1000))
-                .started_at_run_us(req_run_start_us)
-                .finished_at_run_us(req_run_start_us + request_us)
-                .duration_us(request_us)
-                .field(TT_KIND, "request")
-                .field(TT_REQUEST_ID, id)
-                .field(TT_ROUTE, "/checkout")
-                .field(TT_OUTCOME, "ok"),
+                .with_started_at_run_us(req_run_start_us)
+                .with_finished_at_run_us(req_run_start_us + request_us)
+                .with_duration_us(request_us)
+                .with_field(TT_KIND, "request")
+                .with_field(TT_REQUEST_ID, id)
+                .with_field(TT_ROUTE, "/checkout")
+                .with_field(TT_OUTCOME, "ok"),
         );
         spans.push(
             SpanRecord::new("queue", req_start + 1, req_start + 1 + (queue_us / 1000))
-                .started_at_run_us(req_run_start_us + 1_000)
-                .finished_at_run_us(req_run_start_us + 1_000 + queue_us)
-                .duration_us(queue_us)
-                .field(TT_KIND, "queue")
-                .field(TT_REQUEST_ID, id)
-                .field(TT_QUEUE, "permits")
-                .field(TT_DEPTH_AT_START, 3_u64),
+                .with_started_at_run_us(req_run_start_us + 1_000)
+                .with_finished_at_run_us(req_run_start_us + 1_000 + queue_us)
+                .with_duration_us(queue_us)
+                .with_field(TT_KIND, "queue")
+                .with_field(TT_REQUEST_ID, id)
+                .with_field(TT_QUEUE, "permits")
+                .with_field(TT_DEPTH_AT_START, 3_u64),
         );
         spans.push(
             SpanRecord::new("stage", req_start + 85, req_start + 85 + (db_us / 1000))
-                .started_at_run_us(req_run_start_us + 85_000)
-                .finished_at_run_us(req_run_start_us + 85_000 + db_us)
-                .duration_us(db_us)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, id)
-                .field(TT_STAGE, "db")
-                .field(TT_SUCCESS, true),
+                .with_started_at_run_us(req_run_start_us + 85_000)
+                .with_finished_at_run_us(req_run_start_us + 85_000 + db_us)
+                .with_duration_us(db_us)
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, id)
+                .with_field(TT_STAGE, "db")
+                .with_field(TT_SUCCESS, true),
         );
         spans.push(
             SpanRecord::new("stage", req_start + 93, req_start + 93 + (cache_us / 1000))
-                .started_at_run_us(req_run_start_us + 93_000)
-                .finished_at_run_us(req_run_start_us + 93_000 + cache_us)
-                .duration_us(cache_us)
-                .field(TT_KIND, "stage")
-                .field(TT_REQUEST_ID, id)
-                .field(TT_STAGE, "cache")
-                .field(TT_SUCCESS, true),
+                .with_started_at_run_us(req_run_start_us + 93_000)
+                .with_finished_at_run_us(req_run_start_us + 93_000 + cache_us)
+                .with_duration_us(cache_us)
+                .with_field(TT_KIND, "stage")
+                .with_field(TT_REQUEST_ID, id)
+                .with_field(TT_STAGE, "cache")
+                .with_field(TT_SUCCESS, true),
         );
     }
     let imported = run_from_span_records(spans, ImportOptions::new("svc")).unwrap();


### PR DESCRIPTION
### Motivation

- Clarify the public ownership boundary for tracing inputs/outputs so callers only construct `SpanRecord` and Tailtriage owns construction of `ImportedRun`/`ImportWarning` results.
- Make fluent `SpanRecord` construction ergonomics explicit (`with_*` methods) and align getter names with the canonical model fields for clearer, less ambiguous API use.
- Prevent accidental reintroduction of the removed public surface by adding repository-level validation (M02) that enforces the new surface.

### Description

- Renamed `SpanRecord` consuming fluent setters to `with_*`: `id` → `with_id`, `parent_id` → `with_parent_id`, `field` → `with_field`, `started_at_run_us` → `with_started_at_run_us`, `finished_at_run_us` → `with_finished_at_run_us`, and `duration_us` → `with_duration_us`.
- Renamed `SpanRecord` getters to the exact model names: `id_ref` → `id`, `parent_id_ref` → `parent_id`, `started_at_run_us_ref` → `started_at_run_us`, `finished_at_run_us_ref` → `finished_at_run_us`, and `duration_us_ref` → `duration_us`, leaving `name`, `fields`, `started_at_unix_ms`, and `finished_at_unix_ms` unchanged.
- Normalized `ImportOptions` inspection getters: `service_version_ref` → `configured_service_version`, `run_id_ref` → `configured_run_id`, `strict_mode` → `is_strict`, and `mode_value` → `capture_mode`; setters remain unchanged.
- Made `ImportWarning::new(...)` and `ImportedRun::new(...)` crate-private (`pub(crate)`), keeping the public accessor surface (`message`, `run`, `warnings`, `into_parts`, etc.) and preserving internal construction paths (`with_retained_sources`, `into_internal_parts`).
- Migrated external test/demo use sites to the public producer path: `demos/demo_support` tests were updated to call `run_from_span_records(...)` with `SpanRecord` inputs (zero-record and minimal-record cases) rather than constructing `ImportedRun` directly.
- Updated docs and examples (`tailtriage-tracing/README.md`, crate Rustdoc example in `src/lib.rs`, `docs/user-guide.md`, and `CHANGELOG.md`) to teach the new `with_*` syntax and the public boundary `SpanRecord -> run_from_span_records -> ImportedRun`.
- Added enforcement to `scripts/validate_docs_contracts.py` and corresponding Python tests to detect reintroduction of the removed public API forms in `tailtriage-tracing/src/types.rs` and added `TT-TEST: M02 secondary` negative/positive tests in `scripts/tests/test_validate_docs_contracts.py`.

### Testing

- Ran focused package checks and tests for the tracing crate: `cargo check -p tailtriage-tracing --no-default-features --locked`, and `cargo test -p tailtriage-tracing --all-targets --all-features --locked`, all succeeded under the updated codebase.
- Executed full cross-crate test matrix and validation scripts: `cargo test` across `tailtriage-tracing`, `tailtriage-cli`, `tailtriage`, `demo-support`, `demos` examples, and workspace-wide tests; `python3 scripts/validate_docs_contracts.py`; and `python3 scripts/validate_invariant_proofs.py`; all completed successfully.
- Verified public examples and demo parity: `python3 scripts/smoke_public_examples.py`, `python3 scripts/demo_tool.py validate-tracing-parity all --profile release`, and `python3 scripts/demo_tool.py validate-tracing-retention-parity --profile release` passed.
- Ran docs and doc-contract validation and Rustdoc: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`, and `git diff --check`; all checks passed.

If reviewers want, I can split the large rename into smaller follow-up PRs (e.g., types-only, tests-only, docs-only) to simplify review, but this single change set keeps call sites, docs, and policy validators in sync.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a99c33d0814833085d4f1199b242255)