### PR TITLE
api: separate controller sampler rust and toml config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- Controller runtime sampler Rust configuration now uses
+  `RuntimeSamplerTemplate.enabled` and `interval: Option<Duration>` instead of
+  `enabled_for_armed_runs` and `interval_ms`. Controller TOML likewise renames
+  `enabled_for_armed_runs` to `enabled` but keeps `interval_ms`. The public template no longer
+  implements standalone `Serialize` or `Deserialize`; TOML translation is controller-owned.
 - Controller construction now requires output from `.output(...)` or flat
   `controller.activation.output_path`; TOML output and mode override their builder bases, sparse
   reloads return to those original bases, `run_end_policy` is a flat string, and the former public

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -21,6 +21,8 @@ class ValidateDocsContractsTests(unittest.TestCase):
 pub struct TailtriageControllerBuilder;
 pub struct TailtriageControllerTemplate { pub output_path: PathBuf, pub mode: CaptureMode }
 pub struct ControllerActivationTemplate { pub output_path: PathBuf, pub mode: CaptureMode }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RuntimeSamplerTemplate { pub enabled: bool, pub mode_override: Option<CaptureMode>, pub interval: Option<Duration>, pub max_runtime_snapshots: Option<usize> }
 impl TailtriageController { pub fn builder() {} }
 impl TailtriageControllerBuilder { pub const fn mode(self, mode: CaptureMode) -> Self { self } }
 ''',
@@ -198,11 +200,37 @@ impl ImportedRun { pub(crate) fn new() {} }
             with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
                 validate_docs_contracts.validate_residual_public_api_cleanup()
 
+    # TT-TEST: M02 secondary
+    def test_runtime_sampler_template_rejects_removed_fields_and_serde(self) -> None:
+        canonical = self._controller_source()
+        cases = (
+            (canonical.replace('pub enabled: bool', 'pub enabled: bool, pub enabled_for_armed_runs: bool'), 'RuntimeSamplerTemplate::enabled_for_armed_runs'),
+            (canonical.replace('pub interval: Option<Duration>', 'pub interval: Option<Duration>, pub interval_ms: Option<u64>'), 'RuntimeSamplerTemplate::interval_ms'),
+            (canonical.replace('derive(Debug, Clone, Copy, PartialEq, Eq, Default)', 'derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)'), 'RuntimeSamplerTemplate Serialize'),
+            (canonical.replace('derive(Debug, Clone, Copy, PartialEq, Eq, Default)', 'derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)'), 'RuntimeSamplerTemplate Deserialize'),
+            (canonical + '\nimpl Serialize for RuntimeSamplerTemplate {}\n', 'RuntimeSamplerTemplate Serialize'),
+            (canonical + "\nimpl<'de> Deserialize<'de> for RuntimeSamplerTemplate {}\n", 'RuntimeSamplerTemplate Deserialize'),
+        )
+        for source, expected in cases:
+            with self.subTest(expected=expected):
+                self._assert_residual_api_rejected('tailtriage-controller/src/lib.rs', source, expected)
+
+    # TT-TEST: M02 secondary
+    def test_runtime_sampler_template_accepts_private_toml_serde_and_unrelated_milliseconds(self) -> None:
+        self._assert_controller_source_accepted(
+            self._controller_source()
+            + '\npub struct Unrelated { pub interval_ms: Option<u64> }\n'
+            + '#[derive(Deserialize)] struct RuntimeSamplerConfigToml { interval_ms: Option<u64> }\n'
+            + '#[derive(Serialize)] struct TestRuntimeSamplerToml { interval_ms: u64 }\n'
+        )
+
     def _controller_source(self) -> str:
         return '''pub struct TailtriageController;
 pub struct TailtriageControllerBuilder;
 pub struct TailtriageControllerTemplate { pub output_path: PathBuf, pub mode: CaptureMode }
 pub struct ControllerActivationTemplate { pub output_path: PathBuf, pub mode: CaptureMode }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RuntimeSamplerTemplate { pub enabled: bool, pub mode_override: Option<CaptureMode>, pub interval: Option<Duration>, pub max_runtime_snapshots: Option<usize> }
 impl TailtriageController { pub fn builder() {} }
 impl TailtriageControllerBuilder { pub const fn mode(self, mode: CaptureMode) -> Self { self } }
 '''
@@ -413,6 +441,32 @@ pub enum DiagnosisKind {
             parsed={"controller": {"service_name": "checkout", "activation": {"output_path": "run.json", "run_end_policy": "auto_seal_on_limits_hit"}}},
             example_name="synthetic",
         )
+
+    # TT-TEST: M01 secondary
+    def test_controller_toml_contract_accepts_runtime_sampler_fields(self) -> None:
+        validate_docs_contracts._validate_controller_toml_shape(
+            parsed={"controller": {"service_name": "checkout", "activation": {
+                "output_path": "run.json", "runtime_sampler": {"enabled": True,
+                "mode_override": "investigation", "interval_ms": 250,
+                "max_runtime_snapshots": 34}}}}, example_name="synthetic",
+        )
+
+    # TT-TEST: M01 secondary
+    def test_controller_toml_contract_rejects_removed_or_mistyped_sampler_fields(self) -> None:
+        cases = (
+            ({"enabled_for_armed_runs": True}, "enabled_for_armed_runs"),
+            ({"enabled": "true"}, "enabled must be a bool"),
+            ({"enabled": True, "mode_override": "deep"}, "mode_override is invalid"),
+            ({"enabled": True, "interval_ms": "250"}, "interval_ms must be an integer"),
+            ({"enabled": True, "max_runtime_snapshots": False}, "max_runtime_snapshots must be an integer"),
+        )
+        for sampler, expected in cases:
+            with self.subTest(sampler=sampler), self.assertRaisesRegex(ValueError, expected):
+                validate_docs_contracts._validate_controller_toml_shape(
+                    parsed={"controller": {"service_name": "checkout", "activation": {
+                        "output_path": "run.json", "runtime_sampler": sampler}}},
+                    example_name="synthetic",
+                )
 
     # TT-TEST: M01 secondary
     def test_controller_toml_contract_rejects_removed_nested_forms(self) -> None:

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -231,17 +231,32 @@ def _validate_controller_toml_shape(*, parsed: dict[str, Any], example_name: str
         )
 
     run_end_policy = activation.get("run_end_policy")
-    if run_end_policy is None:
-        return
-    if not isinstance(run_end_policy, str):
+    if run_end_policy is not None and not isinstance(run_end_policy, str):
         raise ValueError(f"{example_name} controller README run_end_policy must be a string")
 
     supported_kinds = extract_run_end_policy_kinds_from_source()
-    if run_end_policy not in supported_kinds:
+    if run_end_policy is not None and run_end_policy not in supported_kinds:
         raise ValueError(
             "controller README run_end_policy.kind drift: "
             f"{run_end_policy!r} not in supported {sorted(supported_kinds)}"
         )
+
+    runtime_sampler = activation.get("runtime_sampler")
+    if runtime_sampler is None:
+        return
+    if not isinstance(runtime_sampler, dict):
+        raise ValueError(f"{example_name} controller README runtime_sampler must be a table")
+    if "enabled_for_armed_runs" in runtime_sampler:
+        raise ValueError(f"{example_name} controller README runtime_sampler must not use enabled_for_armed_runs")
+    if not isinstance(runtime_sampler.get("enabled"), bool):
+        raise ValueError(f"{example_name} controller README runtime_sampler.enabled must be a bool")
+    mode_override = runtime_sampler.get("mode_override")
+    if mode_override is not None and mode_override not in {"light", "investigation"}:
+        raise ValueError(f"{example_name} controller README runtime_sampler.mode_override is invalid")
+    for field in ("interval_ms", "max_runtime_snapshots"):
+        value = runtime_sampler.get(field)
+        if value is not None and (not isinstance(value, int) or isinstance(value, bool)):
+            raise ValueError(f"{example_name} controller README runtime_sampler.{field} must be an integer")
 
 
 def normalize_doc_link(link: str) -> str:
@@ -598,6 +613,42 @@ def validate_residual_public_api_cleanup() -> None:
                 raise ValueError(
                     f"tailtriage-controller/src/lib.rs exposes removed residual public API: public {field} field"
                 )
+
+    sampler_declaration = re.search(
+        r"(?P<attributes>(?:\s*#\[[^\]]*\]\s*)*)pub\s+struct\s+RuntimeSamplerTemplate\s*\{",
+        controller_source,
+        flags=re.DOTALL,
+    )
+    if sampler_declaration is None:
+        raise ValueError("tailtriage-controller/src/lib.rs missing canonical public API: RuntimeSamplerTemplate")
+    sampler_body = declaration_bodies(
+        controller_source,
+        controller_path,
+        r"\bpub\s+struct\s+RuntimeSamplerTemplate\s*\{",
+    )[0]
+    required_sampler_fields = (
+        ("enabled", r"\bpub\s+enabled\s*:\s*bool\b"),
+        ("mode_override", r"\bpub\s+mode_override\s*:\s*Option\s*<\s*CaptureMode\s*>"),
+        ("interval", r"\bpub\s+interval\s*:\s*Option\s*<\s*Duration\s*>"),
+        ("max_runtime_snapshots", r"\bpub\s+max_runtime_snapshots\s*:\s*Option\s*<\s*usize\s*>")
+    )
+    for field, pattern in required_sampler_fields:
+        if re.search(pattern, sampler_body) is None:
+            raise ValueError(f"tailtriage-controller/src/lib.rs missing canonical public API: RuntimeSamplerTemplate::{field}")
+    for field in ("enabled_for_armed_runs", "interval_ms"):
+        if re.search(rf"\bpub\s+{field}\s*:", sampler_body):
+            raise ValueError(f"tailtriage-controller/src/lib.rs exposes removed residual public API: RuntimeSamplerTemplate::{field}")
+    attributes = sampler_declaration.group("attributes")
+    for serde_trait in ("Serialize", "Deserialize"):
+        if re.search(rf"derive\s*\([^)]*\b{serde_trait}\b", attributes, re.DOTALL):
+            raise ValueError(f"tailtriage-controller/src/lib.rs exposes removed residual public API: RuntimeSamplerTemplate {serde_trait}")
+    explicit_serde_impls = (
+        ("Serialize", r"\bimpl(?:\s*<[^>]*>)?\s+(?:serde::)?Serialize\s+for\s+RuntimeSamplerTemplate\b"),
+        ("Deserialize", r"\bimpl\s*<[^>]*>\s+(?:serde::)?Deserialize\s*<[^>]*>\s+for\s+RuntimeSamplerTemplate\b"),
+    )
+    for serde_trait, pattern in explicit_serde_impls:
+        if re.search(pattern, controller_source, re.DOTALL):
+            raise ValueError(f"tailtriage-controller/src/lib.rs exposes removed residual public API: RuntimeSamplerTemplate {serde_trait}")
 
     tracing_types_path = REPO_ROOT / "tailtriage-tracing" / "src" / "types.rs"
     tracing_types_source = tracing_types_path.read_text(encoding="utf-8")

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -101,7 +101,7 @@ max_inflight_snapshots = 300000
 max_runtime_snapshots = 150000
 
 [controller.activation.runtime_sampler]
-enabled_for_armed_runs = true
+enabled = true
 mode_override = "investigation"
 interval_ms = 250
 max_runtime_snapshots = 20000
@@ -158,6 +158,28 @@ Important constraints:
 - sampler settings are fixed at activation time
 - runtime snapshot retention is still bounded by the resolved core capture limits
 
+Programmatic Rust configuration uses `enabled` and a native `Option<Duration>` interval:
+
+```rust
+use std::time::Duration;
+use tailtriage_controller::{RuntimeSamplerTemplate, TailtriageController};
+
+let sampler = RuntimeSamplerTemplate {
+    enabled: true,
+    mode_override: None,
+    interval: Some(Duration::from_millis(250)),
+    max_runtime_snapshots: Some(20_000),
+};
+let controller = TailtriageController::builder("checkout-service")
+    .output("tailtriage-run.json")
+    .runtime_sampler(sampler)
+    .build()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+The operator-facing TOML boundary keeps the `interval_ms` integer shown above; the public
+`RuntimeSamplerTemplate` itself is not a standalone serialization type.
+
 ## TOML field reference
 
 ### `[controller]`
@@ -185,7 +207,7 @@ All fields are optional:
 
 Optional table. Default is disabled.
 
-- `enabled_for_armed_runs`
+- `enabled`
 - `mode_override`
 - `interval_ms`
 - `max_runtime_snapshots`

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use tailtriage_core::{
     BuildError, CaptureLimitsOverride, CaptureMode, InflightGuard, Outcome, OwnedRequestCompletion,
     OwnedRequestHandle, QueueTimer, RequestOptions, RunEndReason, StageTimer, Tailtriage,
@@ -263,7 +263,7 @@ fn resolve_controller_template(
             activation.mode.unwrap_or(base.mode),
             activation.capture_limits_override,
             activation.strict_lifecycle,
-            activation.runtime_sampler,
+            activation.runtime_sampler.into(),
             activation.run_end_policy.into(),
         )
     } else {
@@ -677,7 +677,7 @@ impl TailtriageController {
         runtime: &Arc<ActiveGenerationRuntime>,
         run: &Arc<Tailtriage>,
     ) -> Result<(), EnableError> {
-        if !template.runtime_sampler.enabled_for_armed_runs {
+        if !template.runtime_sampler.enabled {
             return Ok(());
         }
 
@@ -687,8 +687,8 @@ impl TailtriageController {
         if let Some(mode_override) = template.runtime_sampler.mode_override {
             sampler_builder = sampler_builder.mode(mode_override);
         }
-        if let Some(interval_ms) = template.runtime_sampler.interval_ms {
-            sampler_builder = sampler_builder.interval(Duration::from_millis(interval_ms));
+        if let Some(interval) = template.runtime_sampler.interval {
+            sampler_builder = sampler_builder.interval(interval);
         }
         if let Some(max_runtime_snapshots) = template.runtime_sampler.max_runtime_snapshots {
             sampler_builder = sampler_builder.max_runtime_snapshots(max_runtime_snapshots);
@@ -1554,14 +1554,14 @@ pub struct TailtriageControllerTemplate {
 }
 
 /// Runtime sampler template attached to controller activation settings.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct RuntimeSamplerTemplate {
     /// Enables runtime sampler startup for armed runs.
-    pub enabled_for_armed_runs: bool,
+    pub enabled: bool,
     /// Optional mode override used by runtime sampler.
     pub mode_override: Option<CaptureMode>,
-    /// Optional interval override in milliseconds.
-    pub interval_ms: Option<u64>,
+    /// Optional runtime sampler interval override.
+    pub interval: Option<Duration>,
     /// Optional max runtime snapshots override.
     pub max_runtime_snapshots: Option<usize>,
 }
@@ -1709,7 +1709,7 @@ impl ControllerConfigFile {
                 mode: activation.mode.unwrap_or(CaptureMode::Light),
                 capture_limits_override: activation.capture_limits_override,
                 strict_lifecycle: activation.strict_lifecycle,
-                runtime_sampler: activation.runtime_sampler,
+                runtime_sampler: activation.runtime_sampler.into(),
                 run_end_policy,
             },
         })
@@ -1743,11 +1743,46 @@ struct ControllerActivationConfigToml {
     #[serde(default)]
     strict_lifecycle: bool,
     #[serde(default)]
-    runtime_sampler: RuntimeSamplerTemplate,
+    runtime_sampler: RuntimeSamplerConfigToml,
     #[serde(default)]
     run_end_policy: RunEndPolicyConfigToml,
     #[serde(default, rename = "sink", deserialize_with = "reject_removed_sink")]
     _removed_sink: (),
+}
+
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+struct RuntimeSamplerConfigToml {
+    enabled: bool,
+    mode_override: Option<CaptureMode>,
+    interval_ms: Option<u64>,
+    max_runtime_snapshots: Option<usize>,
+    #[serde(
+        default,
+        rename = "enabled_for_armed_runs",
+        deserialize_with = "reject_removed_runtime_sampler_enabled"
+    )]
+    _removed_enabled_for_armed_runs: (),
+}
+
+impl From<RuntimeSamplerConfigToml> for RuntimeSamplerTemplate {
+    fn from(value: RuntimeSamplerConfigToml) -> Self {
+        Self {
+            enabled: value.enabled,
+            mode_override: value.mode_override,
+            interval: value.interval_ms.map(Duration::from_millis),
+            max_runtime_snapshots: value.max_runtime_snapshots,
+        }
+    }
+}
+
+fn reject_removed_runtime_sampler_enabled<'de, D>(deserializer: D) -> Result<(), D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let _ = serde::de::IgnoredAny::deserialize(deserializer)?;
+    Err(serde::de::Error::custom(
+        "controller.activation.runtime_sampler.enabled_for_armed_runs is no longer supported; use enabled",
+    ))
 }
 
 fn reject_removed_sink<'de, D>(deserializer: D) -> Result<(), D::Error>
@@ -2123,7 +2158,7 @@ mod tests {
 
     #[derive(Serialize)]
     struct TestRuntimeSamplerToml {
-        enabled_for_armed_runs: bool,
+        enabled: bool,
         mode_override: &'static str,
         interval_ms: u64,
         max_runtime_snapshots: u64,
@@ -2285,7 +2320,7 @@ mod tests {
                     strict_lifecycle: Some(strict),
                     output_path: Some(output.to_path_buf()),
                     runtime_sampler: Some(TestRuntimeSamplerToml {
-                        enabled_for_armed_runs: sampler_enabled,
+                        enabled: sampler_enabled,
                         mode_override: "investigation",
                         interval_ms: 250,
                         max_runtime_snapshots: 123,
@@ -2386,7 +2421,7 @@ mod tests {
                     strict_lifecycle: Some(true),
                     output_path: Some(output.to_path_buf()),
                     runtime_sampler: Some(TestRuntimeSamplerToml {
-                        enabled_for_armed_runs: true,
+                        enabled: true,
                         mode_override: "investigation",
                         interval_ms: 250,
                         max_runtime_snapshots: 34,
@@ -4110,12 +4145,7 @@ mod tests {
                 max_runtime_snapshots: None,
             }
         );
-        assert!(
-            loaded
-                .activation_template
-                .runtime_sampler
-                .enabled_for_armed_runs
-        );
+        assert!(loaded.activation_template.runtime_sampler.enabled);
         assert_eq!(
             loaded.activation_template.run_end_policy,
             RunEndPolicy::AutoSealOnLimitsHit
@@ -4148,9 +4178,9 @@ mod tests {
             },
             strict_lifecycle: true,
             runtime_sampler: RuntimeSamplerTemplate {
-                enabled_for_armed_runs: true,
+                enabled: true,
                 mode_override: Some(CaptureMode::Investigation),
-                interval_ms: Some(250),
+                interval: Some(Duration::from_millis(250)),
                 max_runtime_snapshots: Some(34),
             },
             run_end_policy: RunEndPolicy::AutoSealOnLimitsHit,
@@ -4299,7 +4329,7 @@ output_path = "C:\\Users\\someone\\AppData\\Local\\Temp\\tailtriage.json"
             .build()
             .expect("disabled controller should build outside a runtime");
         let mut template = controller.status().template;
-        template.runtime_sampler.enabled_for_armed_runs = true;
+        template.runtime_sampler.enabled = true;
         let result: Result<(), ReloadTemplateError> = controller.reload_template(template);
         result.expect("pure reload should not require a Tokio runtime");
 
@@ -4347,7 +4377,7 @@ max_requests = 17
 max_stages = 18
 
 [controller.activation.runtime_sampler]
-enabled_for_armed_runs = false
+enabled = false
 "#,
         )
         .expect("invalid config write should succeed");
@@ -4521,9 +4551,9 @@ enabled_for_armed_runs = false
         let controller = TailtriageController::builder("checkout-service")
             .output(&output)
             .runtime_sampler(RuntimeSamplerTemplate {
-                enabled_for_armed_runs: true,
+                enabled: true,
                 mode_override: None,
-                interval_ms: Some(20),
+                interval: Some(Duration::from_millis(20)),
                 max_runtime_snapshots: Some(10),
             })
             .build()
@@ -4538,6 +4568,29 @@ enabled_for_armed_runs = false
             GenerationState::Disabled { next_generation: 1 }
         ));
         assert!(!expected_artifact.exists());
+    }
+
+    // TT-TEST: T04 secondary
+    #[test]
+    fn disabled_sampler_with_populated_options_does_not_require_tokio_runtime() {
+        let output = test_output("disabled-sampler-no-runtime");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .runtime_sampler(RuntimeSamplerTemplate {
+                enabled: false,
+                mode_override: Some(CaptureMode::Investigation),
+                interval: Some(Duration::from_millis(20)),
+                max_runtime_snapshots: Some(100),
+            })
+            .build()
+            .expect("disabled sampler should build outside a runtime");
+        let active = controller
+            .enable()
+            .expect("disabled sampler should enable outside a runtime");
+        controller.disable().expect("generation should finalize");
+        let run = read_run(&active.artifact_path);
+        assert!(run.metadata.effective_tokio_sampler_config.is_none());
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
     // TT-TEST: G05 primary
@@ -4816,7 +4869,7 @@ mode = "light"
 output_path = "tailtriage-run.json"
 
 [controller.activation.runtime_sampler]
-enabled_for_armed_runs = true
+enabled = true
 interval_ms = 20
 max_runtime_snapshots = 10
 "#,
@@ -4831,6 +4884,70 @@ max_runtime_snapshots = 10
             ControllerBuildError::InitialEnable(EnableError::MissingTokioRuntimeForSampler)
         ));
 
+        fs::remove_file(config).expect("config cleanup should succeed");
+    }
+
+    // TT-TEST: T03 secondary
+    #[tokio::test]
+    async fn programmatic_zero_sampler_interval_reaches_sampler_start_validation() {
+        let controller = TailtriageController::builder("checkout-service")
+            .output(test_output("programmatic-zero-sampler-interval"))
+            .runtime_sampler(RuntimeSamplerTemplate {
+                enabled: true,
+                interval: Some(Duration::ZERO),
+                ..RuntimeSamplerTemplate::default()
+            })
+            .build()
+            .expect("build should not validate the sampler interval");
+
+        assert!(matches!(
+            controller.enable(),
+            Err(EnableError::StartRuntimeSampler(
+                tailtriage_tokio::SamplerStartError::ZeroInterval
+            ))
+        ));
+    }
+
+    // TT-TEST: T03 secondary
+    #[tokio::test]
+    async fn toml_zero_sampler_interval_reaches_sampler_start_validation() {
+        let config = test_config_path("toml-zero-sampler-interval");
+        let output = test_output("toml-zero-sampler-interval");
+        write_raw_config(
+            &config,
+            &format!(
+                "[controller]\n[controller.activation]\noutput_path = {output:?}\n[controller.activation.runtime_sampler]\nenabled = true\ninterval_ms = 0\n"
+            ),
+        );
+        let controller = TailtriageController::builder("checkout-service")
+            .config_path(&config)
+            .build()
+            .expect("zero interval TOML should parse and translate");
+        assert_eq!(
+            controller.status().template.runtime_sampler.interval,
+            Some(Duration::ZERO)
+        );
+        assert!(matches!(
+            controller.enable(),
+            Err(EnableError::StartRuntimeSampler(
+                tailtriage_tokio::SamplerStartError::ZeroInterval
+            ))
+        ));
+        fs::remove_file(config).expect("config cleanup should succeed");
+    }
+
+    // TT-TEST: G05 secondary
+    #[test]
+    fn removed_runtime_sampler_enabled_key_is_rejected() {
+        let config = test_config_path("removed-runtime-sampler-enabled-key");
+        write_raw_config(
+            &config,
+            "[controller]\n[controller.activation]\noutput_path = \"run.json\"\n[controller.activation.runtime_sampler]\nenabled_for_armed_runs = true\n",
+        );
+        assert!(matches!(
+            TailtriageController::load_config_from_path(&config),
+            Err(super::ConfigLoadError::Parse { .. })
+        ));
         fs::remove_file(config).expect("config cleanup should succeed");
     }
 
@@ -4860,9 +4977,9 @@ max_runtime_snapshots = 10
         let controller = TailtriageController::builder("checkout-service")
             .output(&output)
             .runtime_sampler(RuntimeSamplerTemplate {
-                enabled_for_armed_runs: true,
+                enabled: true,
                 mode_override: Some(CaptureMode::Investigation),
-                interval_ms: Some(15),
+                interval: Some(Duration::from_millis(20)),
                 max_runtime_snapshots: Some(8),
             })
             .capture_limits_override(CaptureLimitsOverride {
@@ -4890,7 +5007,7 @@ max_runtime_snapshots = 10
             Some(CaptureMode::Investigation)
         );
         assert_eq!(config.resolved_mode, CaptureMode::Investigation);
-        assert_eq!(config.resolved_sampler_cadence_ms, 15);
+        assert_eq!(config.resolved_sampler_cadence_ms, 20);
         assert_eq!(config.resolved_runtime_snapshot_retention, 3);
 
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
@@ -4903,9 +5020,9 @@ max_runtime_snapshots = 10
         let controller = TailtriageController::builder("checkout-service")
             .output(&output)
             .runtime_sampler(RuntimeSamplerTemplate {
-                enabled_for_armed_runs: false,
+                enabled: false,
                 mode_override: Some(CaptureMode::Investigation),
-                interval_ms: Some(5),
+                interval: Some(Duration::from_millis(5)),
                 max_runtime_snapshots: Some(100),
             })
             .build()
@@ -4932,9 +5049,9 @@ max_runtime_snapshots = 10
         let controller = TailtriageController::builder("checkout-service")
             .output(&output)
             .runtime_sampler(RuntimeSamplerTemplate {
-                enabled_for_armed_runs: true,
+                enabled: true,
                 mode_override: None,
-                interval_ms: Some(10),
+                interval: Some(Duration::from_millis(10)),
                 max_runtime_snapshots: Some(32),
             })
             .build()

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -72,16 +72,28 @@ mod tests {
     #[test]
     fn controller_namespace_reexport_compiles() {
         use crate::controller::TailtriageControllerBuilder;
+        use std::time::Duration;
         use tailtriage_core::CaptureMode;
 
+        let sampler = crate::controller::RuntimeSamplerTemplate {
+            enabled: true,
+            mode_override: Some(CaptureMode::Investigation),
+            interval: Some(Duration::from_millis(250)),
+            max_runtime_snapshots: Some(123),
+        };
         let builder: TailtriageControllerBuilder =
             crate::controller::TailtriageController::builder("default-controller")
                 .mode(CaptureMode::Investigation)
-                .output("tailtriage-run.json");
+                .output("tailtriage-run.json")
+                .runtime_sampler(sampler);
         let controller = builder.build().expect("controller should build");
         assert_eq!(
             controller.status().template.mode,
             CaptureMode::Investigation
+        );
+        assert_eq!(
+            controller.status().template.runtime_sampler.interval,
+            Some(Duration::from_millis(250))
         );
     }
 


### PR DESCRIPTION
### Motivation

- Make the controller runtime-sampler a Rust-native programmatic type while keeping the operator TOML boundary operator-friendly and unchanged in semantics. 
- Prevent the public `RuntimeSamplerTemplate` from being a standalone Serde-backed type so TOML parsing is owned by the controller and the public API exposes `Duration` instead of milliseconds.

### Description

- Change the public `RuntimeSamplerTemplate` shape to: `pub enabled: bool`, `pub mode_override: Option<CaptureMode>`, `pub interval: Option<Duration>`, `pub max_runtime_snapshots: Option<usize>` and remove `Serialize`/`Deserialize` derives from it.
- Add a private TOML DTO `RuntimeSamplerConfigToml` (with `interval_ms: Option<u64>` and `enabled: bool`) and an explicit `From<RuntimeSamplerConfigToml> for RuntimeSamplerTemplate` conversion that maps `interval_ms -> Duration::from_millis(...)` and rejects the removed TOML key `enabled_for_armed_runs` with a narrow error message.
- Wire controller config loading to deserialize into `ControllerActivationConfigToml.runtime_sampler: RuntimeSamplerConfigToml` and translate into the public template (no direct TOML -> public-type deserialization anymore).
- Update sampler startup to use `template.runtime_sampler.enabled` and `template.runtime_sampler.interval` (a `Duration`) directly, preserving zero-interval ownership (Tokio sampler still emits `ZeroInterval`).
- Update README, `CHANGELOG.md`, and docs-validator checks to reflect the new TOML key `enabled`, the retained `interval_ms` TOML shape, and the Rust `Option<Duration>` API; add focused tests and extend the M01/M02 validators to protect the final public shape and reject reintroduction of removed fields/Serde.

### Testing

- Ran controller-focused tests: `cargo test -p tailtriage-controller --all-targets --all-features --locked` and all controller tests passed (71 passed).
- Ran workspace tests and validators: `cargo test -p tailtriage --all-targets --all-features --locked`, `python3 -m unittest scripts.tests.test_validate_docs_contracts`, `python3 scripts/validate_docs_contracts.py`, and `python3 scripts/validate_invariant_proofs.py`, all of which succeeded in this run.
- Ran repository completion checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --locked` and `git diff --check`; these checks passed in the change set.
- Added focused tests proving: programmatic `Duration` semantics, TOML translation of `interval_ms`, zero-interval behavior reaches Tokio `ZeroInterval` validation (both programmatic `Duration::ZERO` and `interval_ms = 0`), disabled `enabled = false` with populated optional fields does not start a sampler, and that the removed TOML key `enabled_for_armed_runs` is rejected; all new/updated tests passed as part of the above runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9d4f33519483308b3aa3794dcf18f1)