### PR TITLE
api: encapsulate controller request wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- Controller request, queue, stage, and in-flight wrappers now hide their captured/inert
+  representation. Replace matching on the former `ControllerRequestHandle::{Active, Inert}`
+  variants with `handle.is_captured()`, and use `handle.captured_handle()` only for explicit core
+  `OwnedRequestHandle` interoperability. `InertControllerRequestHandle` is no longer public.
+
 - Controller runtime sampler Rust configuration now uses
   `RuntimeSamplerTemplate.enabled` and `interval: Option<Duration>` instead of
   `enabled_for_armed_runs` and `interval_ms`. Controller TOML likewise renames
@@ -65,7 +70,7 @@
 
 - Removed the deprecated no-op `scripts/validate_all.py --include-cargo` compatibility flag. Cargo completion checks already run by default; omit the flag, or use `--skip-cargo` when intentionally running only the non-Cargo validation tracks.
 
-- Removed residual compatibility-only public APIs before 0.4.0. Migrate `controller.try_begin_request(route)` and `controller.try_begin_request_with(route, options)` to `controller.begin_request(route)` and `controller.begin_request_with(route, options)`; callers that truly need an admission branch can match `ControllerRequestHandle::{Active, Inert}`. Migrate `RuntimeSampler::start(run, interval)?` to `RuntimeSampler::builder(run).interval(interval).start()?`. The `crate_name()` smoke helpers in `tailtriage-tokio` and `tailtriage-axum` were removed without replacement because they were not product behavior. The `tailtriage-cli` command-line package and library documentation target remain supported, but its artifact loader, analyzer-option builder/error, and analyzer-options help renderer are now internal CLI plumbing: use `tailtriage-analyzer` for in-process analysis, `tailtriage-core` for generic Run validation/normalization, and invoke the CLI for saved-artifact command policy.
+- Removed residual compatibility-only public APIs before 0.4.0. Migrate `controller.try_begin_request(route)` and `controller.try_begin_request_with(route, options)` to `controller.begin_request(route)` and `controller.begin_request_with(route, options)`; callers that truly need admission inspection should use `handle.is_captured()` or the explicit core interoperability escape hatch `handle.captured_handle()`. Migrate `RuntimeSampler::start(run, interval)?` to `RuntimeSampler::builder(run).interval(interval).start()?`. The `crate_name()` smoke helpers in `tailtriage-tokio` and `tailtriage-axum` were removed without replacement because they were not product behavior. The `tailtriage-cli` command-line package and library documentation target remain supported, but its artifact loader, analyzer-option builder/error, and analyzer-options help renderer are now internal CLI plumbing: use `tailtriage-analyzer` for in-process analysis, `tailtriage-core` for generic Run validation/normalization, and invoke the CLI for saved-artifact command policy.
 
 - Simplified the analyzer API to one checked `analyze_run` operation plus separate `render_text`, `render_json`, and `render_json_pretty` functions. Migrate `try_analyze_run(...)` to `analyze_run(...)?`, `Analyzer` methods to the free function, `analyze_run_json*` / `try_analyze_run_json*` to analysis followed by `render_json*`, and analyzer strict wrappers to `tailtriage_core::validate_run_strict(...)?` followed by analysis.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -321,11 +321,25 @@ let controller = TailtriageController::builder("checkout-service")
 
 let _generation = controller.enable()?;
 let started = controller.begin_request("/checkout");
+started.handle.queue("db").await_on(async {}).await;
+let _: Result<(), ()> = started
+    .handle
+    .stage("query")
+    .await_on(async { Ok(()) })
+    .await;
+let _guard = started.handle.inflight("requests");
 started.completion.finish_ok();
 let _ = controller.disable()?;
 # Ok(())
 # }
 ```
+
+Ordinary queue, stage, and in-flight instrumentation does not need a capture-state branch.
+Disabled, closing, and shut-down admissions use inert wrappers that execute work transparently
+without recording, while already-captured wrappers stay bound to their original generation.
+When explicit inspection or core interoperability is necessary, use `handle.is_captured()` and
+`handle.captured_handle()`. Captured status records admission identity; it does not report current
+controller enablement.
 
 Controller details: [tailtriage-controller/README.md](../tailtriage-controller/README.md)
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -321,13 +321,15 @@ let controller = TailtriageController::builder("checkout-service")
 
 let _generation = controller.enable()?;
 let started = controller.begin_request("/checkout");
-started.handle.queue("db").await_on(async {}).await;
-let _: Result<(), ()> = started
-    .handle
-    .stage("query")
-    .await_on(async { Ok(()) })
-    .await;
-let _guard = started.handle.inflight("requests");
+{
+    let _guard = started.handle.inflight("requests");
+    started.handle.queue("db").await_on(async {}).await;
+    let _: Result<(), ()> = started
+        .handle
+        .stage("query")
+        .await_on(async { Ok(()) })
+        .await;
+}
 started.completion.finish_ok();
 let _ = controller.disable()?;
 # Ok(())

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -215,6 +215,22 @@ impl ImportedRun { pub(crate) fn new() {} }
                 validate_docs_contracts.validate_residual_public_api_cleanup()
 
     # TT-TEST: M02 secondary
+    def test_controller_request_wrappers_accept_private_tuple_representation(self) -> None:
+        source = self._controller_source()
+        for named, tuple_struct in (
+            ('pub struct ControllerRequestHandle { kind: ControllerRequestKind }',
+             'pub struct ControllerRequestHandle(ControllerRequestKind);'),
+            ("pub struct ControllerQueueTimer<'a> { kind: ControllerQueueTimerKind<'a> }",
+             "pub struct ControllerQueueTimer<'a>(ControllerQueueTimerKind<'a>);"),
+            ("pub struct ControllerStageTimer<'a> { kind: ControllerStageTimerKind<'a> }",
+             "pub struct ControllerStageTimer<'a>(ControllerStageTimerKind<'a>);"),
+            ("pub struct ControllerInflightGuard<'a> { kind: ControllerInflightGuardKind<'a> }",
+             "pub struct ControllerInflightGuard<'a>(ControllerInflightGuardKind<'a>);"),
+        ):
+            source = source.replace(named, tuple_struct)
+        self._assert_controller_source_accepted(source)
+
+    # TT-TEST: M02 secondary
     def test_controller_request_wrappers_must_be_opaque_public_structs(self) -> None:
         canonical = self._controller_source()
         declarations = (
@@ -234,7 +250,10 @@ impl ImportedRun { pub(crate) fn new() {} }
         cases = (
             (canonical.replace('struct InertControllerRequestHandle;', 'pub struct InertControllerRequestHandle;'), 'public InertControllerRequestHandle'),
             (canonical.replace('kind: ControllerRequestKind', 'pub kind: ControllerRequestKind', 1), 'public representation field on ControllerRequestHandle'),
+            (canonical.replace('kind: ControllerRequestKind', 'pub(crate) kind: ControllerRequestKind', 1), 'public representation field on ControllerRequestHandle'),
             (canonical.replace('pub struct ControllerRequestHandle { kind: ControllerRequestKind }', 'pub struct ControllerRequestHandle(pub ControllerRequestKind);'), 'public tuple representation field on ControllerRequestHandle'),
+            (canonical.replace("pub struct ControllerQueueTimer<'a> { kind: ControllerQueueTimerKind<'a> }", "pub struct ControllerQueueTimer<'a>(pub ControllerQueueTimerKind<'a>);"), 'public tuple representation field on ControllerQueueTimer'),
+            (canonical.replace('pub struct ControllerRequestHandle { kind: ControllerRequestKind }', 'pub struct ControllerRequestHandle(pub(crate) ControllerRequestKind);'), 'public tuple representation field on ControllerRequestHandle'),
             (canonical.replace('    pub fn is_captured(&self) -> bool { true }\n', ''), 'ControllerRequestHandle::is_captured'),
             (canonical.replace('    pub fn captured_handle(&self) -> Option<&OwnedRequestHandle> { None }\n', ''), 'ControllerRequestHandle::captured_handle'),
             (canonical.replace('Option<&OwnedRequestHandle>', 'Option<OwnedRequestHandle>'), 'ControllerRequestHandle::captured_handle'),

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -23,6 +23,20 @@ pub struct TailtriageControllerTemplate { pub output_path: PathBuf, pub mode: Ca
 pub struct ControllerActivationTemplate { pub output_path: PathBuf, pub mode: CaptureMode }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct RuntimeSamplerTemplate { pub enabled: bool, pub mode_override: Option<CaptureMode>, pub interval: Option<Duration>, pub max_runtime_snapshots: Option<usize> }
+pub struct ControllerRequestHandle { kind: ControllerRequestKind }
+pub struct ControllerQueueTimer<'a> { kind: ControllerQueueTimerKind<'a> }
+pub struct ControllerStageTimer<'a> { kind: ControllerStageTimerKind<'a> }
+pub struct ControllerInflightGuard<'a> { kind: ControllerInflightGuardKind<'a> }
+enum ControllerRequestKind { Active(OwnedRequestHandle), Inert(InertControllerRequestHandle) }
+enum ControllerQueueTimerKind<'a> { Active(QueueTimer<'a>), Inert }
+enum ControllerStageTimerKind<'a> { Active(StageTimer<'a>), Inert }
+enum ControllerInflightGuardKind<'a> { Active(InflightGuard<'a>), Inert }
+struct InertControllerRequestHandle;
+impl ControllerRequestHandle {
+    pub fn is_captured(&self) -> bool { true }
+    pub fn captured_handle(&self) -> Option<&OwnedRequestHandle> { None }
+}
+pub enum UnrelatedPublicEnum { Active, Inert }
 impl TailtriageController { pub fn builder() {} }
 impl TailtriageControllerBuilder { pub const fn mode(self, mode: CaptureMode) -> Self { self } }
 ''',
@@ -201,6 +215,37 @@ impl ImportedRun { pub(crate) fn new() {} }
                 validate_docs_contracts.validate_residual_public_api_cleanup()
 
     # TT-TEST: M02 secondary
+    def test_controller_request_wrappers_must_be_opaque_public_structs(self) -> None:
+        canonical = self._controller_source()
+        declarations = (
+            ("ControllerRequestHandle", "pub struct ControllerRequestHandle { kind: ControllerRequestKind }", "pub enum ControllerRequestHandle { Active(OwnedRequestHandle), Inert(InertControllerRequestHandle) }"),
+            ("ControllerQueueTimer", "pub struct ControllerQueueTimer<'a> { kind: ControllerQueueTimerKind<'a> }", "pub enum ControllerQueueTimer<'a> { Active(QueueTimer<'a>), Inert }"),
+            ("ControllerStageTimer", "pub struct ControllerStageTimer<'a> { kind: ControllerStageTimerKind<'a> }", "pub enum ControllerStageTimer<'a> { Active(StageTimer<'a>), Inert }"),
+            ("ControllerInflightGuard", "pub struct ControllerInflightGuard<'a> { kind: ControllerInflightGuardKind<'a> }", "pub enum ControllerInflightGuard<'a> { Active(InflightGuard<'a>), Inert }"),
+        )
+        for name, current, exposed in declarations:
+            with self.subTest(name=name):
+                self._assert_residual_api_rejected(
+                    'tailtriage-controller/src/lib.rs',
+                    canonical.replace(current, exposed),
+                    f'public enum {name}',
+                )
+
+        cases = (
+            (canonical.replace('struct InertControllerRequestHandle;', 'pub struct InertControllerRequestHandle;'), 'public InertControllerRequestHandle'),
+            (canonical.replace('kind: ControllerRequestKind', 'pub kind: ControllerRequestKind', 1), 'public representation field on ControllerRequestHandle'),
+            (canonical.replace('pub struct ControllerRequestHandle { kind: ControllerRequestKind }', 'pub struct ControllerRequestHandle(pub ControllerRequestKind);'), 'public tuple representation field on ControllerRequestHandle'),
+            (canonical.replace('    pub fn is_captured(&self) -> bool { true }\n', ''), 'ControllerRequestHandle::is_captured'),
+            (canonical.replace('    pub fn captured_handle(&self) -> Option<&OwnedRequestHandle> { None }\n', ''), 'ControllerRequestHandle::captured_handle'),
+            (canonical.replace('Option<&OwnedRequestHandle>', 'Option<OwnedRequestHandle>'), 'ControllerRequestHandle::captured_handle'),
+        )
+        for source, expected in cases:
+            with self.subTest(expected=expected):
+                self._assert_residual_api_rejected(
+                    'tailtriage-controller/src/lib.rs', source, expected
+                )
+
+    # TT-TEST: M02 secondary
     def test_runtime_sampler_template_rejects_removed_fields_and_serde(self) -> None:
         canonical = self._controller_source()
         cases = (
@@ -231,6 +276,20 @@ pub struct TailtriageControllerTemplate { pub output_path: PathBuf, pub mode: Ca
 pub struct ControllerActivationTemplate { pub output_path: PathBuf, pub mode: CaptureMode }
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct RuntimeSamplerTemplate { pub enabled: bool, pub mode_override: Option<CaptureMode>, pub interval: Option<Duration>, pub max_runtime_snapshots: Option<usize> }
+pub struct ControllerRequestHandle { kind: ControllerRequestKind }
+pub struct ControllerQueueTimer<'a> { kind: ControllerQueueTimerKind<'a> }
+pub struct ControllerStageTimer<'a> { kind: ControllerStageTimerKind<'a> }
+pub struct ControllerInflightGuard<'a> { kind: ControllerInflightGuardKind<'a> }
+enum ControllerRequestKind { Active(OwnedRequestHandle), Inert(InertControllerRequestHandle) }
+enum ControllerQueueTimerKind<'a> { Active(QueueTimer<'a>), Inert }
+enum ControllerStageTimerKind<'a> { Active(StageTimer<'a>), Inert }
+enum ControllerInflightGuardKind<'a> { Active(InflightGuard<'a>), Inert }
+struct InertControllerRequestHandle;
+impl ControllerRequestHandle {
+    pub fn is_captured(&self) -> bool { true }
+    pub fn captured_handle(&self) -> Option<&OwnedRequestHandle> { None }
+}
+pub enum UnrelatedPublicEnum { Active, Inert }
 impl TailtriageController { pub fn builder() {} }
 impl TailtriageControllerBuilder { pub const fn mode(self, mode: CaptureMode) -> Self { self } }
 '''

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -577,6 +577,18 @@ def validate_residual_public_api_cleanup() -> None:
                 raise ValueError(f"{path.relative_to(REPO_ROOT)} has an unclosed declaration")
         return tuple(bodies)
 
+    def delimited_body(source: str, path: Path, body_start: int, opener: str) -> str:
+        closer = {"{": "}", "(": ")"}[opener]
+        depth = 1
+        for index in range(body_start, len(source)):
+            if source[index] == opener:
+                depth += 1
+            elif source[index] == closer:
+                depth -= 1
+                if depth == 0:
+                    return source[body_start:index]
+        raise ValueError(f"{path.relative_to(REPO_ROOT)} has an unclosed declaration")
+
     def impl_bodies(source: str, path: Path, type_name: str) -> tuple[str, ...]:
         return declaration_bodies(
             source, path, rf"\bimpl\s+{type_name}\s*(?:where\b[^{{]*?)?\{{"
@@ -605,20 +617,32 @@ def validate_residual_public_api_cleanup() -> None:
                 "tailtriage-controller/src/lib.rs exposes removed residual public API: "
                 f"public enum {type_name}"
             )
-        if re.search(
-            rf"\bpub\s+struct\s+{type_name}(?:\s*<[^>]+>)?\s*\(\s*pub\b",
+        declaration = re.search(
+            rf"\bpub\s+struct\s+{type_name}(?:\s*<[^>]+>)?\s*(?P<opener>[{{(])",
             controller_source,
+        )
+        if declaration is None:
+            raise ValueError(
+                "tailtriage-controller/src/lib.rs missing required declaration: "
+                f"public struct {type_name}"
+            )
+        opener = declaration.group("opener")
+        body = delimited_body(
+            controller_source, controller_path, declaration.end(), opener
+        )
+        if opener == "{" and re.search(
+            r"\bpub(?:\([^)]*\))?\s+[A-Za-z_]\w*\s*:", body
+        ):
+            raise ValueError(
+                "tailtriage-controller/src/lib.rs exposes removed residual public API: "
+                f"public representation field on {type_name}"
+            )
+        if opener == "(" and re.search(
+            r"(?:^|,)\s*pub(?:\s*\([^)]*\))?\s+", body
         ):
             raise ValueError(
                 "tailtriage-controller/src/lib.rs exposes removed residual public API: "
                 f"public tuple representation field on {type_name}"
-            )
-        declaration = rf"\bpub\s+struct\s+{type_name}(?:\s*<[^>]+>)?\s*\{{"
-        body = declaration_bodies(controller_source, controller_path, declaration)[0]
-        if re.search(r"\bpub(?:\([^)]*\))?\s+[A-Za-z_]\w*\s*:", body):
-            raise ValueError(
-                "tailtriage-controller/src/lib.rs exposes removed residual public API: "
-                f"public representation field on {type_name}"
             )
 
     if re.search(

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -593,6 +593,56 @@ def validate_residual_public_api_cleanup() -> None:
     if any(re.search(rf"{public_function}new\s*\(", body) for body in builder_impls):
         raise ValueError("tailtriage-controller/src/lib.rs exposes removed residual public API: TailtriageControllerBuilder::new")
 
+    wrapper_names = (
+        "ControllerRequestHandle",
+        "ControllerQueueTimer",
+        "ControllerStageTimer",
+        "ControllerInflightGuard",
+    )
+    for type_name in wrapper_names:
+        if re.search(rf"\bpub\s+enum\s+{type_name}\b", controller_source):
+            raise ValueError(
+                "tailtriage-controller/src/lib.rs exposes removed residual public API: "
+                f"public enum {type_name}"
+            )
+        if re.search(
+            rf"\bpub\s+struct\s+{type_name}(?:\s*<[^>]+>)?\s*\(\s*pub\b",
+            controller_source,
+        ):
+            raise ValueError(
+                "tailtriage-controller/src/lib.rs exposes removed residual public API: "
+                f"public tuple representation field on {type_name}"
+            )
+        declaration = rf"\bpub\s+struct\s+{type_name}(?:\s*<[^>]+>)?\s*\{{"
+        body = declaration_bodies(controller_source, controller_path, declaration)[0]
+        if re.search(r"\bpub(?:\([^)]*\))?\s+[A-Za-z_]\w*\s*:", body):
+            raise ValueError(
+                "tailtriage-controller/src/lib.rs exposes removed residual public API: "
+                f"public representation field on {type_name}"
+            )
+
+    if re.search(
+        r"\bpub\s+(?:struct|enum|type)\s+InertControllerRequestHandle\b",
+        controller_source,
+    ):
+        raise ValueError(
+            "tailtriage-controller/src/lib.rs exposes removed residual public API: "
+            "public InertControllerRequestHandle"
+        )
+
+    request_handle_impls = impl_bodies(
+        controller_source, controller_path, "ControllerRequestHandle"
+    )
+    required_request_inspection = (
+        ("ControllerRequestHandle::is_captured", r"\bpub\s+fn\s+is_captured\s*\(\s*&self\s*\)\s*->\s*bool\b"),
+        ("ControllerRequestHandle::captured_handle", r"\bpub\s+fn\s+captured_handle\s*\(\s*&self\s*\)\s*->\s*Option\s*<\s*&\s*OwnedRequestHandle\s*>"),
+    )
+    for symbol, pattern in required_request_inspection:
+        if not any(re.search(pattern, body) for body in request_handle_impls):
+            raise ValueError(
+                f"tailtriage-controller/src/lib.rs missing canonical public API: {symbol}"
+            )
+
     required_controller_patterns = (
         ("TailtriageControllerTemplate::output_path", r"pub struct TailtriageControllerTemplate\s*\{[^}]*\bpub\s+output_path\s*:\s*PathBuf"),
         ("TailtriageControllerTemplate::mode", r"pub struct TailtriageControllerTemplate\s*\{[^}]*\bpub\s+mode\s*:\s*CaptureMode"),

--- a/tailtriage-controller/README.md
+++ b/tailtriage-controller/README.md
@@ -66,6 +66,46 @@ Requests started while the controller is disabled or closing are **inert**:
 
 Each activation writes a per-generation artifact whose file name includes `-generation-N`.
 
+## Request wrappers
+
+Instrument through the controller request wrapper without branching on capture state:
+
+```rust,ignore
+let started = controller.begin_request("/checkout");
+
+started.handle.queue("db").await_on(async {
+    // work
+}).await;
+
+let _: Result<(), ()> = started
+    .handle
+    .stage("query")
+    .await_on(async { Ok(()) })
+    .await;
+
+let _guard = started.handle.inflight("requests");
+```
+
+No capture-state branch is needed for ordinary instrumentation. Admissions made while capture is
+disabled, closing, or shut down return inert wrappers that await work unchanged and record nothing.
+An already-captured wrapper remains tied to the generation that admitted it.
+
+Inspect admission identity only when needed:
+
+```rust,ignore
+if started.handle.is_captured() {
+    // This request was captured when it began.
+}
+
+if let Some(core_handle) = started.handle.captured_handle() {
+    // Explicit interoperability with the core OwnedRequestHandle.
+}
+```
+
+“Captured” is historical admission identity, not the controller's current enablement state.
+`captured_handle()` is the explicit core-interoperability escape hatch; normal instrumentation
+should continue through the controller wrapper.
+
 ## Minimal TOML example
 
 Use TOML when you want repeatable operational settings, including mode selection.

--- a/tailtriage-controller/src/lib.rs
+++ b/tailtriage-controller/src/lib.rs
@@ -851,7 +851,7 @@ impl TailtriageController {
                         active.inflight_captured.fetch_add(1, Ordering::AcqRel);
 
                         return ControllerStartedRequest {
-                            handle: ControllerRequestHandle::Active(started.handle),
+                            handle: ControllerRequestHandle::captured(started.handle),
                             completion: ControllerRequestCompletion {
                                 kind: ControllerCompletionKind::Active(
                                     ActiveControllerCompletion {
@@ -874,7 +874,7 @@ impl TailtriageController {
         }
 
         ControllerStartedRequest {
-            handle: ControllerRequestHandle::Inert(InertControllerRequestHandle::new(
+            handle: ControllerRequestHandle::inert(InertControllerRequestHandle::new(
                 route,
                 options,
                 self.next_inert_request_id(),
@@ -1360,74 +1360,112 @@ impl ActiveControllerCompletion {
     }
 }
 
-/// Instrumentation handle for requests admitted through [`TailtriageController`].
+/// Instrumentation handle for requests begun through [`TailtriageController`].
 #[derive(Debug, Clone)]
-pub enum ControllerRequestHandle {
-    /// Active request handle delegated to one admitted generation.
-    Active(OwnedRequestHandle),
-    /// Inert request handle returned while disabled/closing.
+pub struct ControllerRequestHandle {
+    kind: ControllerRequestKind,
+}
+
+#[derive(Debug, Clone)]
+enum ControllerRequestKind {
+    Captured(OwnedRequestHandle),
     Inert(InertControllerRequestHandle),
 }
 
 impl ControllerRequestHandle {
+    fn captured(handle: OwnedRequestHandle) -> Self {
+        Self {
+            kind: ControllerRequestKind::Captured(handle),
+        }
+    }
+
+    fn inert(handle: InertControllerRequestHandle) -> Self {
+        Self {
+            kind: ControllerRequestKind::Inert(handle),
+        }
+    }
+
+    /// Returns whether this request was captured by a controller generation when it began.
+    ///
+    /// This is immutable admission identity, not the controller's current enablement state.
+    #[must_use]
+    pub fn is_captured(&self) -> bool {
+        matches!(self.kind, ControllerRequestKind::Captured(_))
+    }
+
+    /// Returns the original core handle for explicit interoperability when captured.
+    #[must_use]
+    pub fn captured_handle(&self) -> Option<&OwnedRequestHandle> {
+        match &self.kind {
+            ControllerRequestKind::Captured(handle) => Some(handle),
+            ControllerRequestKind::Inert(_) => None,
+        }
+    }
+
     /// Correlation ID attached to this request.
     #[must_use]
     pub fn request_id(&self) -> &str {
-        match self {
-            Self::Active(handle) => handle.request_id(),
-            Self::Inert(handle) => handle.request_id(),
+        match &self.kind {
+            ControllerRequestKind::Captured(handle) => handle.request_id(),
+            ControllerRequestKind::Inert(handle) => handle.request_id(),
         }
     }
 
     /// Route/operation name attached to this request.
     #[must_use]
     pub fn route(&self) -> &str {
-        match self {
-            Self::Active(handle) => handle.route(),
-            Self::Inert(handle) => handle.route(),
+        match &self.kind {
+            ControllerRequestKind::Captured(handle) => handle.route(),
+            ControllerRequestKind::Inert(handle) => handle.route(),
         }
     }
 
     /// Optional kind metadata attached to this request.
     #[must_use]
     pub fn kind(&self) -> Option<&str> {
-        match self {
-            Self::Active(handle) => handle.kind(),
-            Self::Inert(handle) => handle.kind(),
+        match &self.kind {
+            ControllerRequestKind::Captured(handle) => handle.kind(),
+            ControllerRequestKind::Inert(handle) => handle.kind(),
         }
     }
 
     /// Starts queue-wait timing instrumentation for `queue`.
     #[must_use]
     pub fn queue(&self, queue: impl Into<String>) -> ControllerQueueTimer<'_> {
-        match self {
-            Self::Active(handle) => ControllerQueueTimer::Active(handle.queue(queue)),
-            Self::Inert(_) => ControllerQueueTimer::Inert,
+        match &self.kind {
+            ControllerRequestKind::Captured(handle) => {
+                ControllerQueueTimer::captured(handle.queue(queue))
+            }
+            ControllerRequestKind::Inert(_) => ControllerQueueTimer::inert(),
         }
     }
 
     /// Starts stage timing instrumentation for `stage`.
     #[must_use]
     pub fn stage(&self, stage: impl Into<String>) -> ControllerStageTimer<'_> {
-        match self {
-            Self::Active(handle) => ControllerStageTimer::Active(handle.stage(stage)),
-            Self::Inert(_) => ControllerStageTimer::Inert,
+        match &self.kind {
+            ControllerRequestKind::Captured(handle) => {
+                ControllerStageTimer::captured(handle.stage(stage))
+            }
+            ControllerRequestKind::Inert(_) => ControllerStageTimer::inert(),
         }
     }
 
     /// Creates an in-flight guard for `gauge`.
     #[must_use]
     pub fn inflight(&self, gauge: impl Into<String>) -> ControllerInflightGuard<'_> {
-        match self {
-            Self::Active(handle) => ControllerInflightGuard::Active(handle.inflight(gauge)),
-            Self::Inert(_) => ControllerInflightGuard::Inert,
+        match &self.kind {
+            ControllerRequestKind::Captured(handle) => {
+                ControllerInflightGuard::captured(handle.inflight(gauge))
+            }
+            ControllerRequestKind::Inert(_) => ControllerInflightGuard::inert(),
         }
     }
 }
 
 /// Inert controller request handle metadata stored while disabled/closing.
 #[derive(Debug, Clone)]
-pub struct InertControllerRequestHandle {
+struct InertControllerRequestHandle {
     request_id: String,
     route: String,
     kind: Option<String>,
@@ -1457,20 +1495,35 @@ impl InertControllerRequestHandle {
 
 /// Controller-local queue timer wrapper.
 #[derive(Debug)]
-pub enum ControllerQueueTimer<'a> {
-    /// Queue timer delegated to an active generation.
-    Active(QueueTimer<'a>),
-    /// Inert timer used while disabled/closing.
+pub struct ControllerQueueTimer<'a> {
+    kind: ControllerQueueTimerKind<'a>,
+}
+
+#[derive(Debug)]
+enum ControllerQueueTimerKind<'a> {
+    Captured(QueueTimer<'a>),
     Inert,
 }
 
 impl ControllerQueueTimer<'_> {
+    fn captured(timer: QueueTimer<'_>) -> ControllerQueueTimer<'_> {
+        ControllerQueueTimer {
+            kind: ControllerQueueTimerKind::Captured(timer),
+        }
+    }
+    fn inert() -> Self {
+        Self {
+            kind: ControllerQueueTimerKind::Inert,
+        }
+    }
     /// Sets queue depth sample captured at wait start.
     #[must_use]
     pub fn with_depth_at_start(self, depth_at_start: u64) -> Self {
-        match self {
-            Self::Active(timer) => Self::Active(timer.with_depth_at_start(depth_at_start)),
-            Self::Inert => Self::Inert,
+        match self.kind {
+            ControllerQueueTimerKind::Captured(timer) => {
+                Self::captured(timer.with_depth_at_start(depth_at_start))
+            }
+            ControllerQueueTimerKind::Inert => Self::inert(),
         }
     }
 
@@ -1479,23 +1532,36 @@ impl ControllerQueueTimer<'_> {
     where
         Fut: std::future::Future<Output = T>,
     {
-        match self {
-            Self::Active(timer) => timer.await_on(fut).await,
-            Self::Inert => fut.await,
+        match self.kind {
+            ControllerQueueTimerKind::Captured(timer) => timer.await_on(fut).await,
+            ControllerQueueTimerKind::Inert => fut.await,
         }
     }
 }
 
 /// Controller-local stage timer wrapper.
 #[derive(Debug)]
-pub enum ControllerStageTimer<'a> {
-    /// Stage timer delegated to an active generation.
-    Active(StageTimer<'a>),
-    /// Inert timer used while disabled/closing.
+pub struct ControllerStageTimer<'a> {
+    kind: ControllerStageTimerKind<'a>,
+}
+
+#[derive(Debug)]
+enum ControllerStageTimerKind<'a> {
+    Captured(StageTimer<'a>),
     Inert,
 }
 
 impl ControllerStageTimer<'_> {
+    fn captured(timer: StageTimer<'_>) -> ControllerStageTimer<'_> {
+        ControllerStageTimer {
+            kind: ControllerStageTimerKind::Captured(timer),
+        }
+    }
+    fn inert() -> Self {
+        Self {
+            kind: ControllerStageTimerKind::Inert,
+        }
+    }
     /// Awaits `fut`, recording stage duration for active requests only.
     ///
     /// # Errors
@@ -1505,9 +1571,9 @@ impl ControllerStageTimer<'_> {
     where
         Fut: std::future::Future<Output = Result<T, E>>,
     {
-        match self {
-            Self::Active(timer) => timer.await_on(fut).await,
-            Self::Inert => fut.await,
+        match self.kind {
+            ControllerStageTimerKind::Captured(timer) => timer.await_on(fut).await,
+            ControllerStageTimerKind::Inert => fut.await,
         }
     }
 
@@ -1516,20 +1582,37 @@ impl ControllerStageTimer<'_> {
     where
         Fut: std::future::Future<Output = T>,
     {
-        match self {
-            Self::Active(timer) => timer.await_value(fut).await,
-            Self::Inert => fut.await,
+        match self.kind {
+            ControllerStageTimerKind::Captured(timer) => timer.await_value(fut).await,
+            ControllerStageTimerKind::Inert => fut.await,
         }
     }
 }
 
 /// Controller-local in-flight guard wrapper.
 #[derive(Debug)]
-pub enum ControllerInflightGuard<'a> {
-    /// In-flight guard delegated to an active generation.
-    Active(InflightGuard<'a>),
-    /// Inert guard used while disabled/closing.
+pub struct ControllerInflightGuard<'a> {
+    _kind: ControllerInflightGuardKind<'a>,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)] // The captured guard is intentionally held solely for its Drop lifetime.
+enum ControllerInflightGuardKind<'a> {
+    Captured(InflightGuard<'a>),
     Inert,
+}
+
+impl ControllerInflightGuard<'_> {
+    fn captured(guard: InflightGuard<'_>) -> ControllerInflightGuard<'_> {
+        ControllerInflightGuard {
+            _kind: ControllerInflightGuardKind::Captured(guard),
+        }
+    }
+    fn inert() -> Self {
+        Self {
+            _kind: ControllerInflightGuardKind::Inert,
+        }
+    }
 }
 
 /// Template configuration that the controller applies to future activations.
@@ -2540,10 +2623,7 @@ mod tests {
         closure_reached.recv().expect("disable should reach hook");
         release_admission.send(()).expect("release admission first");
         let admitted = admitting.join().expect("admission thread should join");
-        assert!(matches!(
-            admitted.handle,
-            super::ControllerRequestHandle::Active(_)
-        ));
+        assert!(admitted.handle.is_captured());
         assert_eq!(
             admission_runtime.inflight_captured.load(Ordering::Acquire),
             1
@@ -2604,10 +2684,7 @@ mod tests {
             .send(())
             .expect("release admission second");
         let inert = admitting.join().expect("admission thread should join");
-        assert!(matches!(
-            inert.handle,
-            super::ControllerRequestHandle::Inert(_)
-        ));
+        assert!(!inert.handle.is_captured());
         assert_eq!(disable_runtime.inflight_captured.load(Ordering::Acquire), 0);
         let generation_one_run = read_run(&disable_generation.artifact_path);
         assert!(generation_one_run
@@ -2740,6 +2817,7 @@ mod tests {
 
         let active = controller.enable().expect("enable should succeed");
         let started = controller.begin_request("/checkout");
+        assert!(started.handle.is_captured());
 
         let disable = controller.disable().expect("disable should succeed");
         assert!(matches!(
@@ -2749,6 +2827,8 @@ mod tests {
                 inflight_captured_requests: 1
             } if generation_id == active.generation_id
         ));
+        assert!(started.handle.is_captured());
+        assert!(started.handle.captured_handle().is_some());
 
         started.completion.finish_ok();
 
@@ -2810,10 +2890,7 @@ mod tests {
         assert!(active_status.accepting_new_admissions);
         assert!(!active_status.closing);
         assert_eq!(active_status.inflight_captured_requests, 0);
-        assert!(matches!(
-            &refused_one.handle,
-            super::ControllerRequestHandle::Inert(_)
-        ));
+        assert!(!refused_one.handle.is_captured());
         assert_eq!(refused_one.handle.request_id(), "refused-one");
         assert_eq!(refused_one.handle.kind(), Some("test"));
 
@@ -2905,10 +2982,7 @@ mod tests {
         assert!(status.closing);
         assert!(!status.accepting_new_admissions);
         assert_eq!(status.inflight_captured_requests, 1);
-        assert!(matches!(
-            &refused.handle,
-            super::ControllerRequestHandle::Inert(_)
-        ));
+        assert!(!refused.handle.is_captured());
 
         refused.completion.finish_ok();
         assert!(matches!(
@@ -2998,10 +3072,7 @@ mod tests {
             panic!("continue policy should remain active");
         };
         assert_eq!(status.inflight_captured_requests, 0);
-        assert!(matches!(
-            &refused.handle,
-            super::ControllerRequestHandle::Inert(_)
-        ));
+        assert!(!refused.handle.is_captured());
         assert!(matches!(
             controller.disable(),
             Ok(DisableOutcome::Finalized { generation_id }) if generation_id == active.generation_id
@@ -3282,6 +3353,8 @@ mod tests {
             RequestOptions::new().request_id("req-disabled"),
         );
         assert_eq!(disabled_started.handle.request_id(), "req-disabled");
+        assert!(!disabled_started.handle.is_captured());
+        assert!(disabled_started.handle.captured_handle().is_none());
         disabled_started.completion.finish_ok();
 
         let active = controller.enable().expect("enable should succeed");
@@ -3301,8 +3374,8 @@ mod tests {
     }
 
     // TT-TEST: support
-    #[test]
-    fn disabled_handle_and_completion_operations_are_noop() {
+    #[tokio::test]
+    async fn disabled_handle_and_completion_operations_are_noop() {
         let output = test_output("disabled-noop");
         let controller = TailtriageController::builder("checkout-service")
             .output(&output)
@@ -3319,10 +3392,26 @@ mod tests {
         assert_eq!(started.handle.request_id(), "req-disabled-noop");
         assert_eq!(started.handle.route(), "/checkout");
         assert_eq!(started.handle.kind(), Some("http"));
+        assert!(!started.handle.is_captured());
+        assert!(started.handle.captured_handle().is_none());
         let request = started.handle.clone();
         let _inflight = request.inflight("inflight-disabled");
-        let _queue = request.queue("queue-disabled");
-        let _stage = request.stage("stage-disabled");
+        let queued = request
+            .queue("queue-disabled")
+            .with_depth_at_start(9)
+            .await_on(async { 4_u8 })
+            .await;
+        assert_eq!(queued, 4);
+        let staged = request
+            .stage("stage-disabled")
+            .await_on(async { Err::<(), _>("stage-error") })
+            .await;
+        assert_eq!(staged, Err("stage-error"));
+        let value = request
+            .stage("value-disabled")
+            .await_value(async { 8_u8 })
+            .await;
+        assert_eq!(value, 8);
         started
             .completion
             .finish_result::<(), &str>(Err("disabled-result"))
@@ -3341,6 +3430,61 @@ mod tests {
         assert!(run.contains("req-enabled"));
         assert!(!run.contains("req-disabled-noop"));
 
+        fs::remove_file(active.artifact_path).expect("cleanup should succeed");
+    }
+
+    // TT-TEST: support
+    #[tokio::test]
+    async fn captured_handle_inspection_and_branch_free_instrumentation_share_core_request() {
+        let output = test_output("captured-handle-inspection");
+        let controller = TailtriageController::builder("checkout-service")
+            .output(&output)
+            .build()
+            .expect("build should succeed");
+        let active = controller.enable().expect("enable should succeed");
+        let started = controller.begin_request_with(
+            "/checkout",
+            RequestOptions::new()
+                .request_id("req-captured")
+                .kind("http"),
+        );
+
+        assert!(started.handle.is_captured());
+        let core = started
+            .handle
+            .captured_handle()
+            .expect("captured request should expose the original core handle");
+        assert_eq!(core.request_id(), started.handle.request_id());
+        assert_eq!(core.route(), started.handle.route());
+        assert_eq!(core.kind(), started.handle.kind());
+
+        started
+            .handle
+            .queue("db")
+            .with_depth_at_start(3)
+            .await_on(async {})
+            .await;
+        let result: Result<(), ()> = started
+            .handle
+            .stage("query")
+            .await_on(async { Ok(()) })
+            .await;
+        assert_eq!(result, Ok(()));
+        let value = started
+            .handle
+            .stage("decode")
+            .await_value(async { 7_u8 })
+            .await;
+        assert_eq!(value, 7);
+        drop(started.handle.inflight("requests"));
+        started.completion.finish_ok();
+
+        controller.disable().expect("disable should succeed");
+        let run = read_run(&active.artifact_path);
+        assert_eq!(run.queues.len(), 1);
+        assert_eq!(run.queues[0].depth_at_start, Some(3));
+        assert_eq!(run.stages.len(), 2);
+        assert_eq!(run.inflight.len(), 2);
         fs::remove_file(active.artifact_path).expect("cleanup should succeed");
     }
 
@@ -3582,6 +3726,7 @@ mod tests {
             .expect("build should succeed");
         let active = controller.enable().expect("enable should succeed");
         let started = controller.begin_request("/checkout");
+        assert!(started.handle.is_captured());
 
         assert!(matches!(
             controller.shutdown(),
@@ -3599,6 +3744,12 @@ mod tests {
             controller.status().generation,
             GenerationState::Shutdown
         ));
+        assert!(started.handle.is_captured());
+        assert!(started.handle.captured_handle().is_some());
+        let post_shutdown = controller.begin_request("/post-shutdown");
+        assert!(!post_shutdown.handle.is_captured());
+        assert!(post_shutdown.handle.captured_handle().is_none());
+        post_shutdown.completion.finish_ok();
         assert!(matches!(
             controller.enable(),
             Err(EnableError::ControllerShutdown)

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -71,7 +71,7 @@ mod tests {
     #[cfg(feature = "controller")]
     #[test]
     fn controller_namespace_reexport_compiles() {
-        use crate::controller::TailtriageControllerBuilder;
+        use crate::controller::{ControllerRequestHandle, TailtriageControllerBuilder};
         use std::time::Duration;
         use tailtriage_core::CaptureMode;
 
@@ -95,6 +95,11 @@ mod tests {
             controller.status().template.runtime_sampler.interval,
             Some(Duration::from_millis(250))
         );
+        let started = controller.begin_request("/checkout");
+        let handle: &ControllerRequestHandle = &started.handle;
+        let _captured: bool = handle.is_captured();
+        let _core: Option<&crate::OwnedRequestHandle> = handle.captured_handle();
+        started.completion.finish_ok();
     }
 
     // TT-TEST: P02 primary


### PR DESCRIPTION
### Motivation

- Prevent downstream pattern-matching on controller internal variants while preserving the same external semantics for instrumentation and metadata. 
- Provide a safe, explicit inspection hook for callers that need core interop without making that the normal usage path. 
- Keep branch-free queue/stage/inflight instrumentation and all generation/finish semantics unchanged.

### Description

- Replaced public enum representations with opaque public structs for the four wrapper types: `ControllerRequestHandle`, `ControllerQueueTimer<'a>`, `ControllerStageTimer<'a>`, and `ControllerInflightGuard<'a>`, backed by private `Kind` enums holding captured/inert state. 
- Removed `InertControllerRequestHandle` from the public surface (kept as a private implementation type) and updated construction sites to use `ControllerRequestHandle::captured(...)` / `ControllerRequestHandle::inert(...)`. 
- Added the exact inspection APIs on `ControllerRequestHandle`: `pub fn is_captured(&self) -> bool` and `pub fn captured_handle(&self) -> Option<&OwnedRequestHandle>`, implemented to return immutable admission identity and a reference to the original core handle when captured. 
- Converted `ControllerQueueTimer`, `ControllerStageTimer`, and `ControllerInflightGuard` from public enums to opaque public structs with private kinds and preserved their fluent and awaiting APIs (`with_depth_at_start`, `await_on`, `await_value`, RAII drop behavior). 
- Migrated tests to observe `is_captured()` / `captured_handle()` instead of matching `Active`/`Inert`, added focused tests that validate inspection semantics and branch-free instrumentation still records evidence against admitted generations, and extended fixtures to cover inert transparency and post-shutdown inert behavior. 
- Updated facade compile proof (`tailtriage` tests), controller README, user guide snippets, and CHANGELOG migration guidance to teach `is_captured()` / `captured_handle()` instead of pattern matching. 
- Extended `scripts/validate_docs_contracts.py` and its unit tests to lexically enforce M02 rules preventing public enum forms or public representation fields for the four wrapper names and to require the exact inspection methods on `ControllerRequestHandle`.

### Testing

- Ran focused controller unit tests: `cargo test -p tailtriage-controller --all-targets --all-features --locked` and all controller tests passed. 
- Ran facade/unit tests and workspace tests: `cargo test -p tailtriage --all-targets --all-features --locked` and `cargo test --workspace --all-targets --all-features --locked`; all tests passed. 
- Ran docs and policy validators: `python3 -m unittest scripts.tests.test_validate_docs_contracts`, `python3 scripts/validate_docs_contracts.py`, and `python3 scripts/validate_invariant_proofs.py`; they all succeeded. 
- Executed public example smoke checks: `python3 scripts/smoke_public_examples.py`; all public examples validated successfully. 
- Performed full repository completion checks: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --all-features --no-deps --locked`, and `git diff --check`; these validations passed with no remaining issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9e9ed63a248330b3cf54865ac5889e)