### PR TITLE
api: curate facade core reexports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Changed
 
+- Tracing JSONL import now accepts only the stable `tailtriage.tracing-span.v1` wrapper through
+  `import_jsonl_reader(...)` and `import_jsonl_path(...)`. `JsonlParseMode`,
+  `import_jsonl_reader_with_mode(...)`, and `import_jsonl_path_with_mode(...)` were removed;
+  callers with legacy or pre-stable compatible records must convert them externally to the stable
+  wrapper before import.
+- The default `tailtriage` facade now explicitly reexports the supported `tailtriage-core` root
+  API instead of glob-reexporting every compiler-public core item. The doc-hidden
+  `tailtriage_core::__internal` sibling bridge is intentionally not exposed as
+  `tailtriage::__internal`; it is unsupported integration plumbing, not a user migration target.
+
 - Controller request, queue, stage, and in-flight wrappers now hide their captured/inert
   representation. Replace matching on the former `ControllerRequestHandle::{Active, Inert}`
   variants with `handle.is_captured()`, and use `handle.captured_handle()` only for explicit core

--- a/docs/dev/DESIGN_NOTES.md
+++ b/docs/dev/DESIGN_NOTES.md
@@ -747,6 +747,19 @@ Core Run integrity contract:
 - Strict entry points validate the original unnormalized candidate and reject error-level core findings. Warning-only missing optional precision does not reject.
 - Tracing provenance keeps retained source spans private through normalization and writes completed-span JSONL directly from retained original sources. Stable JSONL intake accepts only the `tailtriage.tracing-span.v1` wrapper.
 
+## Cross-crate internal integration hooks
+
+Prefer private or `pub(crate)` visibility for implementation details inside one crate. Rust has no
+friend-crate visibility for separate workspace crates, so `tailtriage_core::__internal` is an
+intentionally doc-hidden, compiler-public bridge for narrow sibling integration protocols. Every
+hook placed there must have Rustdoc naming the owning sibling integration and explaining why the
+hook should not be ordinary user API. Do not use `__internal` as a dumping ground for convenience
+APIs or general utilities.
+
+If a hook becomes genuinely appropriate for downstream users, promote it deliberately into the
+supported API with normal documentation, tests, and changelog treatment. The default `tailtriage`
+facade intentionally excludes this bridge and exposes only the supported core root API.
+
 
 
 ### Partial queue and stage events

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -378,6 +378,54 @@ impl ImportedRun {}
         )
 
     # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_accepts_single_explicit_item(self) -> None:
+        self._assert_facade_sources_accepted(
+            'pub use artifact::Run;\n', 'pub use tailtriage_core::Run;\n'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_single_alias(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use tailtriage_core::Run as RunMetadata;\n', 'must not alias'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_equal_name_set_alias_swap(self) -> None:
+        self._assert_facade_sources_rejected(
+            'pub use artifact::{Run, RunMetadata};\n',
+            'pub use tailtriage_core::{\n'
+            '    Run as RunMetadata,\n'
+            '    RunMetadata as Run,\n'
+            '};\n',
+            'must not alias',
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_braced_whole_crate(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use {tailtriage_core};\n', 'whole tailtriage_core'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_braced_whole_crate_alias(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use {tailtriage_core as core};\n', 'whole tailtriage_core'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_braced_whole_crate_internal_alias(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use {tailtriage_core as __internal};\n', 'whole tailtriage_core'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_mixed_braced_whole_crate(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use {tailtriage_core, some_other_crate::Thing};\n',
+            'whole tailtriage_core',
+        )
+
+    # TT-TEST: M02 secondary
     def test_facade_core_reexport_policy_rejects_glob(self) -> None:
         self._assert_facade_sources_rejected(
             'pub use artifact::{Run};\n', 'pub use tailtriage_core :: * ;\n', 'glob-reexport'

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -384,6 +384,58 @@ impl ImportedRun {}
         )
 
     # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_whole_crate_reexport(self) -> None:
+        self._assert_facade_bypass_rejected('pub use tailtriage_core;\n', 'whole tailtriage_core')
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_whole_crate_alias(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use tailtriage_core as core;\n', 'whole tailtriage_core'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_whole_crate_internal_alias(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use tailtriage_core as __internal;\n', 'whole tailtriage_core'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_group_self(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use tailtriage_core::{self, Run};\n', 'whole tailtriage_core'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_group_aliased_self(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use tailtriage_core::{self as core, Run};\n', 'whole tailtriage_core'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_nested_internal_glob(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use tailtriage_core::__internal::*;\n', 'glob-reexport'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_non_internal_nested_glob(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use tailtriage_core::some_public_module::*;\n', 'glob-reexport'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_explicit_internal_alias(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use tailtriage_core::__internal as internal;\n', '__internal'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_grouped_internal_alias(self) -> None:
+        self._assert_facade_bypass_rejected(
+            'pub use tailtriage_core::{Run, __internal as internal};\n', '__internal'
+        )
+
+    # TT-TEST: M02 secondary
     def test_facade_core_reexport_policy_rejects_internal_exposure(self) -> None:
         core = 'pub use artifact::{Run};\n#[doc(hidden)]\npub mod __internal {}\n'
         for facade in (
@@ -421,6 +473,13 @@ impl ImportedRun {}
         self._assert_facade_sources_accepted(
             'pub use artifact::Run;\n#[doc(hidden)]\npub mod __internal {}\n',
             'pub use tailtriage_core::{Run};\n',
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_accepts_private_core_use(self) -> None:
+        self._assert_facade_sources_accepted(
+            'pub use artifact::Run;\n',
+            'pub use tailtriage_core::Run;\nuse tailtriage_core::__internal as internal;\n',
         )
 
     # TT-TEST: M02 secondary
@@ -466,6 +525,11 @@ impl ImportedRun {}
     def _assert_facade_sources_rejected(self, core: str, facade: str, error: str) -> None:
         with self.assertRaisesRegex(ValueError, error):
             self._assert_facade_sources_accepted(core, facade)
+
+    def _assert_facade_bypass_rejected(self, bypass: str, error: str) -> None:
+        core = 'pub use artifact::{Run, RunMetadata};\n'
+        facade = 'pub use tailtriage_core::{Run, RunMetadata};\n' + bypass
+        self._assert_facade_sources_rejected(core, facade, error)
 
     # TT-TEST: M02 secondary
     def test_residual_public_api_cleanup_rejects_removed_tracing_surface_in_where_impl(self) -> None:

--- a/scripts/tests/test_validate_docs_contracts.py
+++ b/scripts/tests/test_validate_docs_contracts.py
@@ -47,6 +47,7 @@ impl TailtriageControllerBuilder { pub const fn mode(self, mode: CaptureMode) ->
             'tailtriage-core/src/collector.rs': '',
             'tailtriage-core/src/run_builder.rs': '',
             'tailtriage-core/src/lib.rs': '',
+            'tailtriage/src/lib.rs': '',
             'tailtriage-analyzer/src/options/mod.rs': 'pub struct AnalyzeOptionDescriptor { path: &\'static str }\nimpl AnalyzeOptionDescriptor { pub(crate) fn new() {} }\n',
             'tailtriage-analyzer/src/options/overrides.rs': 'fn valid_override_paths() {}\npub(crate) fn valid_override_paths_for_crate() {}\n',
             'tailtriage-analyzer/src/lib.rs': 'pub enum DiagnosisKind { ApplicationQueuePressure, BlockingPoolPressure, ExecutorPressure, DownstreamStageDominance, InsufficientEvidence, }\n',
@@ -68,6 +69,10 @@ impl ImportOptions {
 impl ImportOptions {}
 impl ImportWarning { pub(crate) fn new() {} }
 impl ImportedRun { pub(crate) fn new() {} }
+''',
+            'tailtriage-tracing/src/jsonl.rs': '''enum JsonlParseMode {}
+fn import_jsonl_reader_with_mode() {}
+fn import_jsonl_path_with_mode() {}
 ''',
         }
         sources.update(overrides or {})
@@ -363,6 +368,104 @@ impl ImportedRun {}
                 self._assert_residual_api_rejected(
                     'tailtriage-tracing/src/types.rs', source, symbol
                 )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_accepts_canonical_explicit_set(self) -> None:
+        self._assert_facade_sources_accepted(
+            'pub use artifact::{Run, RunMetadata};\npub use sink::{RunSink, SinkError};\n'
+            '#[doc(hidden)]\npub mod __internal {}\n',
+            'pub use tailtriage_core::{Run, RunMetadata, RunSink, SinkError};\n',
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_glob(self) -> None:
+        self._assert_facade_sources_rejected(
+            'pub use artifact::{Run};\n', 'pub use tailtriage_core :: * ;\n', 'glob-reexport'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_internal_exposure(self) -> None:
+        core = 'pub use artifact::{Run};\n#[doc(hidden)]\npub mod __internal {}\n'
+        for facade in (
+            'pub use tailtriage_core::{Run, __internal};\n',
+            'pub use tailtriage_core::{Run};\npub mod __internal;\n',
+        ):
+            with self.subTest(facade=facade):
+                self._assert_facade_sources_rejected(core, facade, '__internal')
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_missing_supported_item(self) -> None:
+        self._assert_facade_sources_rejected(
+            'pub use artifact::{Run, RunMetadata};\n',
+            'pub use tailtriage_core::{Run};\n',
+            'missing=',
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_rejects_extra_item(self) -> None:
+        self._assert_facade_sources_rejected(
+            'pub use artifact::{Run};\n',
+            'pub use tailtriage_core::{Run, Unsupported};\n',
+            'extra=',
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_ignores_order_grouping_and_whitespace(self) -> None:
+        self._assert_facade_sources_accepted(
+            'pub use artifact::{Run, RunMetadata};\npub use sink::RunSink;\n',
+            'pub use tailtriage_core :: {\n RunSink,\nRunMetadata , Run\n};\n',
+        )
+
+    # TT-TEST: M02 secondary
+    def test_facade_core_reexport_policy_accepts_doc_hidden_core_internal_module(self) -> None:
+        self._assert_facade_sources_accepted(
+            'pub use artifact::Run;\n#[doc(hidden)]\npub mod __internal {}\n',
+            'pub use tailtriage_core::{Run};\n',
+        )
+
+    # TT-TEST: M02 secondary
+    def test_removed_jsonl_parse_mode_public_enum_is_rejected(self) -> None:
+        self._assert_residual_api_rejected(
+            'tailtriage-tracing/src/jsonl.rs', 'pub enum JsonlParseMode {}\n', 'JsonlParseMode'
+        )
+
+    # TT-TEST: M02 secondary
+    def test_removed_jsonl_reader_with_mode_public_function_is_rejected(self) -> None:
+        self._assert_residual_api_rejected(
+            'tailtriage-tracing/src/jsonl.rs',
+            'pub fn import_jsonl_reader_with_mode<R: Read>(reader: R) {}\n',
+            'import_jsonl_reader_with_mode',
+        )
+
+    # TT-TEST: M02 secondary
+    def test_removed_jsonl_path_with_mode_public_function_is_rejected(self) -> None:
+        self._assert_residual_api_rejected(
+            'tailtriage-tracing/src/jsonl.rs',
+            'pub fn import_jsonl_path_with_mode(path: &Path) {}\n',
+            'import_jsonl_path_with_mode',
+        )
+
+    # TT-TEST: M02 secondary
+    def test_removed_jsonl_compatibility_names_are_accepted_when_private(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            self._write_residual_api_sources(root)
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
+                validate_docs_contracts.validate_residual_public_api_cleanup()
+
+    def _assert_facade_sources_accepted(self, core: str, facade: str) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            self._write_residual_api_sources(root, {
+                'tailtriage-core/src/lib.rs': core,
+                'tailtriage/src/lib.rs': facade,
+            })
+            with mock.patch.object(validate_docs_contracts, 'REPO_ROOT', root):
+                validate_docs_contracts.validate_residual_public_api_cleanup()
+
+    def _assert_facade_sources_rejected(self, core: str, facade: str, error: str) -> None:
+        with self.assertRaisesRegex(ValueError, error):
+            self._assert_facade_sources_accepted(core, facade)
 
     # TT-TEST: M02 secondary
     def test_residual_public_api_cleanup_rejects_removed_tracing_surface_in_where_impl(self) -> None:

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -496,6 +496,30 @@ def _explicit_reexport_names(body: str, *, required_prefix: str | None = None) -
 def _facade_core_reexport_names(body: str) -> set[str] | None:
     """Validate and extract one public use rooted at ``tailtriage_core``."""
     compact = re.sub(r"\s+", "", re.sub(r"\bas\b", "@", body))
+
+    outer_group = re.fullmatch(r"\{(?P<items>.*)\}", compact)
+    if outer_group:
+        names: set[str] = set()
+        found_core_use = False
+        depth = 0
+        item_start = 0
+        items = outer_group.group("items")
+        for index, character in enumerate(items + ","):
+            if character == "{":
+                depth += 1
+            elif character == "}":
+                depth -= 1
+            elif character == "," and depth == 0:
+                item = items[item_start:index]
+                item_start = index + 1
+                if not item:
+                    continue
+                item_names = _facade_core_reexport_names(item)
+                if item_names is not None:
+                    found_core_use = True
+                    names.update(item_names)
+        return names if found_core_use else None
+
     if compact == "tailtriage_core" or compact.startswith("tailtriage_core@"):
         raise ValueError("tailtriage/src/lib.rs must not reexport the whole tailtriage_core crate")
     if not compact.startswith("tailtriage_core::"):
@@ -511,17 +535,19 @@ def _facade_core_reexport_names(body: str) -> set[str] | None:
     for item in items:
         if not item:
             continue
-        source, separator, alias = item.partition("@")
+        source, separator, _alias = item.partition("@")
         source_segments = source.split("::")
         if "__internal" in source_segments:
             raise ValueError("tailtriage/src/lib.rs must not reexport tailtriage_core::__internal")
         if source == "self":
             raise ValueError("tailtriage/src/lib.rs must not reexport the whole tailtriage_core crate")
+        if separator:
+            raise ValueError("tailtriage/src/lib.rs must not alias tailtriage_core reexports")
         if len(source_segments) != 1:
             raise ValueError(
                 "tailtriage/src/lib.rs may only explicitly reexport tailtriage_core root items"
             )
-        names.add(alias if separator else source)
+        names.add(source)
     return names
 
 

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -493,6 +493,38 @@ def _explicit_reexport_names(body: str, *, required_prefix: str | None = None) -
     return names
 
 
+def _facade_core_reexport_names(body: str) -> set[str] | None:
+    """Validate and extract one public use rooted at ``tailtriage_core``."""
+    compact = re.sub(r"\s+", "", re.sub(r"\bas\b", "@", body))
+    if compact == "tailtriage_core" or compact.startswith("tailtriage_core@"):
+        raise ValueError("tailtriage/src/lib.rs must not reexport the whole tailtriage_core crate")
+    if not compact.startswith("tailtriage_core::"):
+        return None
+
+    remainder = compact[len("tailtriage_core::") :]
+    if "*" in remainder:
+        raise ValueError("tailtriage/src/lib.rs must not glob-reexport tailtriage_core")
+
+    group = re.fullmatch(r"\{(?P<items>[^{}]*)\}", remainder)
+    items = group.group("items").split(",") if group else [remainder]
+    names: set[str] = set()
+    for item in items:
+        if not item:
+            continue
+        source, separator, alias = item.partition("@")
+        source_segments = source.split("::")
+        if "__internal" in source_segments:
+            raise ValueError("tailtriage/src/lib.rs must not reexport tailtriage_core::__internal")
+        if source == "self":
+            raise ValueError("tailtriage/src/lib.rs must not reexport the whole tailtriage_core crate")
+        if len(source_segments) != 1:
+            raise ValueError(
+                "tailtriage/src/lib.rs may only explicitly reexport tailtriage_core root items"
+            )
+        names.add(alias if separator else source)
+    return names
+
+
 def validate_facade_core_reexport_policy() -> None:
     """Require the facade to mirror supported core root reexports without internals."""
     core_path = REPO_ROOT / "tailtriage-core" / "src" / "lib.rs"
@@ -504,17 +536,14 @@ def validate_facade_core_reexport_policy() -> None:
     for body in _root_public_use_bodies(core_source):
         expected.update(_explicit_reexport_names(body))
 
-    if re.search(r"(?m)^pub[ \t]+use[ \t]+tailtriage_core[ \t]*::[ \t]*\*[ \t]*;", facade_source):
-        raise ValueError("tailtriage/src/lib.rs must not glob-reexport tailtriage_core")
     if re.search(r"(?m)^[ \t]*pub[ \t]+mod[ \t]+__internal\b", facade_source):
         raise ValueError("tailtriage/src/lib.rs must not declare __internal")
 
     actual: set[str] = set()
     for body in _root_public_use_bodies(facade_source):
-        names = _explicit_reexport_names(body, required_prefix="tailtriage_core")
-        if "__internal" in names:
-            raise ValueError("tailtriage/src/lib.rs must not reexport tailtriage_core::__internal")
-        actual.update(names)
+        names = _facade_core_reexport_names(body)
+        if names is not None:
+            actual.update(names)
 
     if actual != expected:
         missing = sorted(expected - actual)

--- a/scripts/validate_docs_contracts.py
+++ b/scripts/validate_docs_contracts.py
@@ -461,7 +461,73 @@ def validate_crate_rustdocs_include_readmes() -> None:
         raise ValueError("crate rustdoc README include contract violation:\n" + "\n".join(failures))
 
 
+def _root_public_use_bodies(source: str) -> tuple[str, ...]:
+    """Return semicolon-terminated public-use bodies that begin at the crate root."""
+    return tuple(
+        match.group("body")
+        for match in re.finditer(
+            r"(?ms)^pub[ \t]+use[ \t]+(?P<body>.*?);", source
+        )
+    )
+
+
+def _explicit_reexport_names(body: str, *, required_prefix: str | None = None) -> set[str]:
+    compact = re.sub(r"\s+", "", body)
+    if required_prefix is not None:
+        prefix = f"{required_prefix}::"
+        if not compact.startswith(prefix):
+            return set()
+        compact = compact[len(prefix):]
+    if compact == "*" or "::*" in compact:
+        return set()
+
+    group = re.fullmatch(r"[^{}]*\{(?P<items>[^{}]*)\}", compact)
+    items = group.group("items").split(",") if group else [compact]
+    names: set[str] = set()
+    for item in items:
+        if not item:
+            continue
+        name = item.rsplit("::", 1)[-1]
+        if name != "self":
+            names.add(name)
+    return names
+
+
+def validate_facade_core_reexport_policy() -> None:
+    """Require the facade to mirror supported core root reexports without internals."""
+    core_path = REPO_ROOT / "tailtriage-core" / "src" / "lib.rs"
+    facade_path = REPO_ROOT / "tailtriage" / "src" / "lib.rs"
+    core_source = core_path.read_text(encoding="utf-8")
+    facade_source = facade_path.read_text(encoding="utf-8")
+
+    expected: set[str] = set()
+    for body in _root_public_use_bodies(core_source):
+        expected.update(_explicit_reexport_names(body))
+
+    if re.search(r"(?m)^pub[ \t]+use[ \t]+tailtriage_core[ \t]*::[ \t]*\*[ \t]*;", facade_source):
+        raise ValueError("tailtriage/src/lib.rs must not glob-reexport tailtriage_core")
+    if re.search(r"(?m)^[ \t]*pub[ \t]+mod[ \t]+__internal\b", facade_source):
+        raise ValueError("tailtriage/src/lib.rs must not declare __internal")
+
+    actual: set[str] = set()
+    for body in _root_public_use_bodies(facade_source):
+        names = _explicit_reexport_names(body, required_prefix="tailtriage_core")
+        if "__internal" in names:
+            raise ValueError("tailtriage/src/lib.rs must not reexport tailtriage_core::__internal")
+        actual.update(names)
+
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(
+            "tailtriage facade supported core reexport set mismatch: "
+            f"missing={missing}, extra={extra}"
+        )
+
+
 def validate_residual_public_api_cleanup() -> None:
+    validate_facade_core_reexport_policy()
+
     forbidden_by_path = {
         REPO_ROOT / "tailtriage-controller" / "src" / "lib.rs": (
             "pub fn try_begin_request(",
@@ -545,6 +611,17 @@ def validate_residual_public_api_cleanup() -> None:
             (
                 "AnalyzeOptions::valid_override_paths",
                 r"\bpub\s+(?:const\s+)?fn\s+valid_override_paths\s*\(",
+            ),
+        ),
+        REPO_ROOT / "tailtriage-tracing" / "src" / "jsonl.rs": (
+            ("public JsonlParseMode", r"\bpub\s+enum\s+JsonlParseMode\b"),
+            (
+                "public import_jsonl_reader_with_mode",
+                r"\bpub\s+fn\s+import_jsonl_reader_with_mode\s*(?:<[^>{}]*>)?\s*\(",
+            ),
+            (
+                "public import_jsonl_path_with_mode",
+                r"\bpub\s+fn\s+import_jsonl_path_with_mode\s*(?:<[^>{}]*>)?\s*\(",
             ),
         ),
     }

--- a/tailtriage-core/src/lib.rs
+++ b/tailtriage-core/src/lib.rs
@@ -64,24 +64,39 @@ pub use validation::{
     RUN_RELATIVE_DURATION_TOLERANCE_US,
 };
 
-/// Internal integration hooks for sibling crates in this workspace.
+/// Compiler-public integration hooks for sibling crates in this workspace.
+///
+/// Workspace packages are separate Rust crates, so sibling integrations cannot call core
+/// `pub(crate)` internals. These items are public only at the compiler level to provide that
+/// narrow bridge. The module is hidden from documentation, excluded from the supported end-user
+/// API contract, and may change without the compatibility guarantees of supported public APIs.
+/// Ordinary core implementation details must remain private or `pub(crate)`.
 #[doc(hidden)]
 pub mod __internal {
     use crate::{EffectiveTokioSamplerConfig, RunEndReason, Tailtriage};
 
-    /// Internal duplicate-registration signal for the Tokio integration.
+    /// Internal cross-crate protocol signal used by the Tokio integration.
+    ///
+    /// This is not a supported user-facing core error type.
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct DuplicateRuntimeSampler;
 
-    /// Sets controller-owned run-end provenance without exposing live mutation publicly.
+    /// Sets controller-owned run-end provenance for the controller integration.
+    ///
+    /// Controller lifecycle owns this mutation. The hook exists only so
+    /// `tailtriage-controller` can stamp controller-owned run-end provenance; exposing it as
+    /// ordinary application API would let callers forge or mutate that provenance independently
+    /// of controller state.
     pub fn set_run_end_reason_if_absent(tailtriage: &Tailtriage, reason: RunEndReason) {
         tailtriage.set_run_end_reason_if_absent(reason);
     }
 
     /// Escapes control characters for human-readable output in workspace sibling integrations.
     ///
-    /// This is not a general serialization or Unicode security mechanism. It is a doc-hidden,
-    /// unsupported integration hook for rendering dynamic fields at human-output boundaries.
+    /// This shares human-output escaping across sibling Tailtriage crates. It is not part of core
+    /// capture, Run-schema, validation, persistence, or lifecycle semantics; promoting it would
+    /// create an unrelated generic text-utility API commitment. It is also not a general
+    /// serialization or Unicode security mechanism.
     #[must_use]
     pub fn escape_control_chars(input: &str) -> String {
         let mut output = String::with_capacity(input.len());
@@ -97,9 +112,10 @@ pub mod __internal {
 
     /// Registers Tokio sampler startup metadata after real sampler preconditions pass.
     ///
-    /// This is an intentionally narrow cross-crate boundary for
-    /// `tailtriage-tokio` integration. It is hidden from docs and not a
-    /// supported end-user API surface.
+    /// Tokio sampler registration is owned by `tailtriage-tokio`, which invokes this hook only
+    /// after its runtime and startup preconditions pass. Making it ordinary public core API would
+    /// let applications forge effective Tokio sampler metadata without going through that
+    /// integration.
     ///
     /// # Errors
     ///

--- a/tailtriage/src/lib.rs
+++ b/tailtriage/src/lib.rs
@@ -2,11 +2,24 @@
 #![warn(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
-/// Re-export of `tailtriage-core`, always available at the crate root.
+/// Explicit re-export of the supported `tailtriage-core` API, always available at the crate root.
 ///
-/// This crate is the recommended default entry point: start with core APIs here,
-/// then enable optional integration namespaces via feature flags as needed.
-pub use tailtriage_core::*;
+/// Internal sibling integration hooks are deliberately excluded.
+pub use tailtriage_core::{
+    decode_run_json_path, inspect_run, normalize_run_permissive, summarize_run_validation,
+    summarize_run_validation_lifecycle, system_time_to_unix_ms, unix_time_ms, validate_run_strict,
+    BuildError, CaptureLimits, CaptureLimitsOverride, CaptureMode, DiscardSink,
+    EffectiveCoreConfig, EffectiveTokioSamplerConfig, InFlightSnapshot, InflightGuard,
+    LocalJsonSink, MemorySink, NormalizedRun, Outcome, OwnedRequestCompletion, OwnedRequestHandle,
+    OwnedStartedRequest, QueueEvent, QueueTimer, RequestCompletion, RequestEvent, RequestHandle,
+    RequestOptions, Run, RunBuilder, RunBuilderError, RunBuilderEventError, RunBuilderOptions,
+    RunEndReason, RunEventDisposition, RunEventDispositionKind, RunJsonDecodeError, RunMetadata,
+    RunSection, RunSink, RunValidationError, RunValidationIssue, RunValidationIssueCode,
+    RunValidationLocation, RunValidationReport, RunValidationSeverity, RuntimeSnapshot,
+    ShutdownError, SinkError, StageEvent, StageTimer, StartedRequest, Tailtriage,
+    TailtriageBuilder, TruncationSummary, UnfinishedRequestSample, UnfinishedRequests,
+    RUN_RELATIVE_DURATION_TOLERANCE_US, SCHEMA_VERSION,
+};
 
 #[cfg(feature = "axum")]
 #[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
@@ -40,9 +53,33 @@ pub use tailtriage_tracing as tracing;
 mod tests {
     // TT-TEST: P01 primary
     #[test]
-    fn core_reexport_exposes_tailtriage() {
-        let _builder =
-            crate::Tailtriage::builder("default-smoke").sink(tailtriage_core::DiscardSink);
+    fn core_reexport_exposes_supported_cross_section() {
+        use crate::{
+            validate_run_strict, EffectiveTokioSamplerConfig, OwnedRequestHandle, QueueTimer, Run,
+            RunBuilder, RunSink, RunValidationReport, ShutdownError, SinkError, Tailtriage,
+            TailtriageBuilder, SCHEMA_VERSION,
+        };
+
+        type CoreTypes<'a> = (
+            TailtriageBuilder,
+            OwnedRequestHandle,
+            ShutdownError,
+            Run,
+            RunBuilder,
+            &'a dyn RunSink,
+            SinkError,
+            RunValidationReport,
+            QueueTimer<'a>,
+            EffectiveTokioSamplerConfig,
+        );
+
+        let _builder = Tailtriage::builder("default-smoke").sink(crate::DiscardSink);
+        let _: Option<CoreTypes<'_>> = None;
+        std::hint::black_box(
+            validate_run_strict as fn(&Run) -> Result<(), crate::RunValidationError>,
+        );
+        std::hint::black_box(crate::unix_time_ms as fn() -> u64);
+        std::hint::black_box(SCHEMA_VERSION);
     }
 
     // TT-TEST: P01 primary


### PR DESCRIPTION
### Motivation

- Stop exposing the undocumented compiler-public core internals through the default `tailtriage` facade while preserving the intentional doc-hidden sibling-crate bridge in `tailtriage-core`.
- Make the default `tailtriage` crate explicitly reexport only the supported `tailtriage-core` root API so consumers cannot accidentally rely on unsupported internal hooks.
- Record and communicate why each `__internal` hook exists and why it is not ordinary public API to avoid accidental promotion of integration plumbing into the public contract.
- Add mechanical checks so the facade cannot silently regress to a glob reexport or re-expose removed tracing JSONL compatibility symbols.

### Description

- Replaced the glob `pub use tailtriage_core::*;` in `tailtriage/src/lib.rs` with an exhaustive, explicit reexport list of the supported `tailtriage-core` root API and added a brief crate-root rustdoc noting that internal sibling hooks are excluded.
- Added concise maintainer-facing guidance to `docs/dev/DESIGN_NOTES.md` explaining the cross-crate `tailtriage_core::__internal` bridge rule and when hooks must be promoted into supported APIs.
- Expanded `tailtriage-core/src/lib.rs` module docs for `#[doc(hidden)] pub mod __internal` and added per-hook Rustdoc explaining why each hook remains internal (coverage for `DuplicateRuntimeSampler`, `set_run_end_reason_if_absent`, `escape_control_chars`, and `register_tokio_runtime_sampler`).
- Extended `scripts/validate_docs_contracts.py` and `scripts/tests/test_validate_docs_contracts.py` with an M02 check that (a) rejects `pub use tailtriage_core::*;`, (b) rejects reexport or facade exposure of `__internal`, (c) requires the facade reexport set to match core root `pub use` declarations, and (d) rejects exact public reintroductions of `JsonlParseMode`, `import_jsonl_reader_with_mode`, and `import_jsonl_path_with_mode` in `tailtriage-tracing/src/jsonl.rs`.
- Strengthened the P01 compile proof in `tailtriage/src/lib.rs` to import/black-box a representative cross-section of supported core types (construction, request handles, Run model, RunBuilder, sinks, validation/time/timers, schema/version and Tokio sampler config) to keep the facade-proof semantics intact.
- Recorded migration notes in `CHANGELOG.md` for the tracing JSONL removal and for the facade curation describing the intent and migration guidance.

### Testing

- Ran the docs contract validator `python3 scripts/validate_docs_contracts.py` and the extended Python unit tests `python3 -m unittest scripts.tests.test_validate_docs_contracts`, which completed successfully with all tests passing.
- Ran `cargo test -p tailtriage --all-targets --all-features --locked` and full workspace `cargo test --workspace --all-targets --all-features --locked`, and all Rust tests passed.
- Ran lint/doc checks including `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`, and `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps --locked`, all of which succeeded.
- Ran smoke and invariant checks (`python3 scripts/smoke_public_examples.py`, `python3 scripts/validate_invariant_proofs.py`) and they succeeded, confirming examples and invariant proofs remain valid.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9f1bc8da788330953f1e41f0cf1afb)